### PR TITLE
Add a Github action for running code linters

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+name: Run linters on code
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - name: Install modules
+      run: npm install
+    - run: npm run lint

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,5 +6,8 @@
   "no-inline-html": false,
   "no-trailing-punctuation": false,
   "no-duplicate-heading": false,
-  "no-bare-urls": false
+  "no-bare-urls": false,
+  "no-multiple-blanks": false,
+  "commands-show-output": false,
+  "fenced-code-language": false
 }

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -31,17 +31,17 @@ footer {
 }
 
 h3 a {
-	color: #1d2d35;
+  color: #1d2d35;
 }
 
 .menu-icon {
-	padding: 0.375rem 0.625rem !important;
+  padding: 0.375rem 0.625rem !important;
 }
 
 .navbar-brand {
-	color: #0053fa !important;
+  color: #0053fa !important;
 }
 
 body.home .navbar-brand {
-	display: none; // hide on home page
+  display: none; // hide on home page
 }

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -73,7 +73,7 @@ $border-color:                $gray-200;
 // Font, line-height, and color for body text, headings, and more.
 
 // stylelint-disable value-keyword-case
-$font-family-sans-serif:      'Open Sans', -apple-system, blinkmacsystemfont, "Segoe UI", roboto, "Helvetica Neue", arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+$font-family-sans-serif:      "Open Sans", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, "Helvetica Neue", arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 $font-family-monospace:       sfmono-regular, menlo, monaco, consolas, "Liberation Mono", "Courier New", monospace;
 $font-family-base:            $font-family-sans-serif;
 // stylelint-enable value-keyword-case

--- a/content/blog/why-i-built-litestream/index.md
+++ b/content/blog/why-i-built-litestream/index.md
@@ -39,7 +39,7 @@ exponentially faster. So why do we need more computers than ever before?
 
 Since early web languages like PHP and Ruby were slow, you didn't want them
 running on your database server so you moved them to their own servers in what
-is called an [n-tier architecture][n-tier]. Now you can keep adding more 
+is called an [n-tier architecture][n-tier]. Now you can keep adding more
 stateless Ruby servers to this _presentation layer_ and scale your application.
 
 Database servers like Oracle, PostgreSQL, and MySQL tended to be complicated to
@@ -128,7 +128,7 @@ your server dies, so does your data. That's... not good.
 Other database servers have replication so they can stream database changes to
 another server in case one goes down. The best you can hope for with standard
 SQLite is to run a nightly backup. Solutions like [rqlite][] are great but
-it requires a 3-node cluster. 
+it requires a 3-node cluster.
 
 Why can't SQLite have a replication tool that's as easy to use as SQLite?
 
@@ -196,10 +196,10 @@ start of it. There are exciting features coming including replication to
 copies of your database at the edge to deliver requests instantly.
 
 If you're interested in trying out Litestream, the [Getting
-Started](/getting-started) can get you up and running in less than 10 minutes. 
+Started](/getting-started) can get you up and running in less than 10 minutes.
 
 I'm interested to hear from others that want to simplify and improve application
-development. If you have ideas or thoughts about the future of Litestream, 
+development. If you have ideas or thoughts about the future of Litestream,
 please get in touch on the [GitHub Discussions board][discussions] and drop me a
 line.
 

--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -26,7 +26,7 @@ install it separately.
 
 ### Creating an S3 bucket
 
-If you don't already have an Amazon AWS account, you can go 
+If you don't already have an Amazon AWS account, you can go
 [https://aws.amazon.com/](https://aws.amazon.com/) and click "Create Account".
 Once you have an account, you'll need to create an AWS IAM user with
 _programmatic access_ and with `AmazonS3FullAccess` permissions. After creating
@@ -34,7 +34,7 @@ the user, you should have an **access key id** and a **secret access key**. We
 will use those in one of the steps below. <a href='/videos/iam.mp4'>Click here
 to watch a short video on creating an AWS IAM user.</a>
 
-You’ll also need to create a bucket in AWS S3. You’ll need to create a unique name for your bucket. 
+You’ll also need to create a bucket in AWS S3. You’ll need to create a unique name for your bucket.
 
 {{< alert icon="❗️" text="In this tutorial, we’ll name our bucket 'mybkt.litestream.io' but replace that with your bucket name, like 'mybkt.yourdomain.com'." >}}
 
@@ -95,7 +95,7 @@ you will see there is a `fruits.db` directory in your bucket.
 
 ## Restoring your database
 
-**In a third terminal window**, we'll restore our database to a new file. First, 
+**In a third terminal window**, we'll restore our database to a new file. First,
 make sure your environment variables are set correctly:
 
 ```sh
@@ -168,4 +168,3 @@ Litestream was built to run as a background service that you don't need to worry
 about—it just replicates your database all the time. To run Litestream as a
 background service, please refer to the [How-To Guides section](/guides) to
 run on your particular platform.
-

--- a/content/guides/systemd.md
+++ b/content/guides/systemd.md
@@ -33,7 +33,7 @@ install it separately.
 
 ### Creating an S3 bucket
 
-If you don't already have an Amazon AWS account, you can go 
+If you don't already have an Amazon AWS account, you can go
 [https://aws.amazon.com/](https://aws.amazon.com/) and click "Create Account".
 Once you have an account, you'll need to [create an AWS IAM user][iam] with
 _programmatic access_ and with `AmazonS3FullAccess` permissions. After creating
@@ -159,4 +159,3 @@ Kelly
 
 You now have a production-ready replication setup using SQLite and Litestream.
 Please see the [Reference](/reference) section for more configuration options.
-

--- a/content/how-it-works/_index.md
+++ b/content/how-it-works/_index.md
@@ -40,7 +40,7 @@ perform checkpoints as necessary.
 
 The shadow WAL is a directory next to your SQLite database where WAL files are
 effectively recreated as a sequence. The first shadow WAL file starts with
-`00000000.wal` and when a checkpoint occurs then it starts copying to 
+`00000000.wal` and when a checkpoint occurs then it starts copying to
 `00000001.wal`.
 
 These WAL files contain the original WAL frames & checksums to ensure
@@ -68,8 +68,6 @@ snapshot. This ensures we always have a contiguous set of files to replay even
 if Litestream is stopped and misses WAL frames being written.
 
 This approach also has the benefit that two servers that accidentally share
-the same replica destination will not overwrite each other's data. However, 
+the same replica destination will not overwrite each other's data. However,
 note that it is not recommended to replicate two databases to the same exact
 replica path.
-
-

--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -79,7 +79,7 @@ Litestream currently supports two types of replicas:
 - `"s3"` replicates a database to an S3 bucket.
 - `"file"` replicates a database to another local file path.
 
-All replicas have unique name which is specified by the `"name"` field. If a 
+All replicas have unique name which is specified by the `"name"` field. If a
 name is not specified then the name defaults to the replica type.
 
 

--- a/content/reference/generations.md
+++ b/content/reference/generations.md
@@ -8,7 +8,7 @@ menu:
 weight: 520
 ---
 
-The `generations` command lists all generations for a database or replica. It 
+The `generations` command lists all generations for a database or replica. It
 lists stats about their lag behind the primary database and the time range
 they cover.
 


### PR DESCRIPTION
The code was currently not passing `npm run lint`, so I added some lint rule suppressions to the markdown lint. Long-term, we can remove them and make the linters more strict, but I figured that it's better to have the linters start with a basic set of rules to enforce and then tighten them up in subsequent PRs.