### PR TITLE
Fix minio option to specify address in getting started

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -41,7 +41,7 @@ want to use persistent storage in a production environment.
 First, start your MinIO instance:
 
 ```sh
-docker run -p 9000:9000 -p 9001:9001 minio/minio server /data --address ":9001"
+docker run -p 9000:9000 -p 9001:9001 minio/minio server /data --console-address ":9001"
 ```
 
 Then open a web browser to <a href="http://localhost:9001/" target="_blank">http://localhost:9001/</a>


### PR DESCRIPTION
Thank you for the wonderful product!

I found a typo in https://litestream.io/getting-started/#setting-up-minio.

`--address` is an option to specify the port of API and `--console--address` is an option to specify the port of console.
I think `--console--address` should be used here.

### Using `--address`

A dynamic port will be used for console. It's unexpected.

```
$ docker run -p 9000:9000 -p 9001:9001 minio/minio server /data --address ":9001"
API: http://172.17.0.2:9001  http://127.0.0.1:9001 

Console: http://172.17.0.2:35819 http://127.0.0.1:35819 

Documentation: https://docs.min.io

WARNING: Console endpoint is listening on a dynamic port (35819), please use --console-address ":PORT" to choose a static port.
Finished loading IAM sub-system (took 0.0s of 0.0s to load data).
```

### Using `--console-address`

`9001` will be used for console. It's expected.

```
$ docker run -p 9000:9000 -p 9001:9001 minio/minio server /data --console-address ":9001"
API: http://172.17.0.2:9000  http://127.0.0.1:9000 

Console: http://172.17.0.2:9001 http://127.0.0.1:9001 

Documentation: https://docs.min.io
Finished loading IAM sub-system (took 0.0s of 0.0s to load data).
```

Thanks,
