### PR TITLE
Service Account is only needed if running outside of GCP

### DIFF
--- a/content/guides/gcs/index.md
+++ b/content/guides/gcs/index.md
@@ -31,7 +31,7 @@ and click the _"Create"_ button.
 
 ### Create a service account
 
-On a Compute Engine VM or Cloud Run service, Litestreamwill automatically pick
+On a Compute Engine VM or Cloud Run service, Litestream will automatically pick
 up the credentials associated with the instance from the instance's metadata
 server.
 

--- a/content/guides/gcs/index.md
+++ b/content/guides/gcs/index.md
@@ -31,8 +31,13 @@ and click the _"Create"_ button.
 
 ### Create a service account
 
-You'll need to set up a service account to authenticate into GCP and access your
-bucket. From the top search bar, navigate to _"Service Accounts"_. Enter a name
+On a Compute Engine VM or Cloud Run service, Litestreamwill automatically pick
+up the credentials associated with the instance from the instance's metadata
+server.
+
+If you run Litestream outside of Google Cloud, you'll need to set up a service 
+account to authenticate into GCP and access your bucket.
+From the top search bar, navigate to _"Service Accounts"_. Enter a name
 for your service account and click the _"Create"_ button.
 
 Next, you'll need to grant the _Storage Object Creator_ and _Storage Object


### PR DESCRIPTION
On a GCE VM, credentials are automatically picked up from the instance by the cloud storage library.