### PR TITLE
Fix Config Typo for AWS Region Name

### DIFF
--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -148,7 +148,7 @@ dbs:
   - path: /var/lib/db
     replicas:
       - url: s3://mybkt.litestream.io/db
-        region: us-east1
+        region: us-east-1
         access-key-id: AKIAxxxxxxxxxxxxxxxx
         secret-access-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxx
 ```


### PR DESCRIPTION
Changes the region from `us-east1` -> `us-east-1`