### PR TITLE
Update reference to replicate command arguments

### DIFF
--- a/content/reference/replicate.md
+++ b/content/reference/replicate.md
@@ -44,6 +44,10 @@ litestream replicate [arguments] DB_PATH REPLICA_URL [REPLICA_URL...]
     Specifies the configuration file.
     Defaults to /etc/litestream.yml
 
+-exec CMD
+    Executes a subcommand. Litestream will exit when the child
+    process exits. Useful for simple process management.
+
 -no-expand-env
     Disables environment variable expansion in configuration file.
 

--- a/content/reference/replicate.md
+++ b/content/reference/replicate.md
@@ -50,9 +50,4 @@ litestream replicate [arguments] DB_PATH REPLICA_URL [REPLICA_URL...]
 
 -no-expand-env
     Disables environment variable expansion in configuration file.
-
--trace PATH
-    Write verbose trace logging to PATH.
-    This trace file can produce a lot of data
-    and is not recommended for production systems.
 ```


### PR DESCRIPTION
Update reference to replicate command arguments

* Add `-exec`
  * https://github.com/benbjohnson/litestream/blob/e4254bbf69893cf5e17c52df9036bfa35e6941ae/cmd/litestream/replicate.go#L201-L203
* Remove `-trace`