### PR TITLE
Fix configuration reference for local file path

### DIFF
--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -87,7 +87,7 @@ dbs:
 
   - path: /var/lib/db2
     replicas:
-      - path: /backup/db2
+      - file: /backup/db2
       - url:  s3://mybkt.litestream.io/db2
 ```
 


### PR DESCRIPTION
I am not certain that this is right but "path" is not mentioned below this as an option for replicas.