### PR TITLE
Include `sqlite_rsync` on alternatives page

### DIFF
--- a/content/alternatives/_index.md
+++ b/content/alternatives/_index.md
@@ -30,6 +30,13 @@ also be used in conjunction with Litestream as a fallback.
 Please see our [guide to running a cron-based backup strategy](/alternatives/cron).
 
 
+## SQLite Rsync
+
+As of SQLite [3.47.0](https://www.sqlite.org/releaselog/3_47_0.html), the included
+[`sqlite3_rsync`](https://sqlite.org/rsync.html) utility may be used to
+perform bandwidth-efficient live backups over SSH.
+
+
 ## LiteFS
 
 [LiteFS](https://github.com/superfly/litefs) is a distributed file system that


### PR DESCRIPTION
This PR updates the Alternatives page with a new entry for the `sqlite_rsync` utility that was released in SQLite [3.47.0](https://www.sqlite.org/releaselog/3_47_0.html) on 21 October 2024.
