### PR TITLE
Fix S3 policy

### DIFF
--- a/content/guides/s3/index.md
+++ b/content/guides/s3/index.md
@@ -160,8 +160,7 @@ The following is the minimum policy to use with Litestream. Please replace the
                 "s3:GetObject"
             ],
             "Resource": [
-                "arn:aws:s3:::<BUCKET>/*",
-                "arn:aws:s3:::<BUCKET>"
+                "arn:aws:s3:::<BUCKET>/*"
             ]
         }
     ]


### PR DESCRIPTION
s3:PutObject, s3:DeleteObject and s3:GetObject are object specific permissions so adding the bucket as a resource is redundant.

![permissions](https://github.com/user-attachments/assets/34d25411-8994-4c1e-a696-6c14a1179ed7)