### PR TITLE
Fix: Revert docs to v0.3.13 and add v0.5.0 feature notices

### DIFF
--- a/content/guides/nats/index.md
+++ b/content/guides/nats/index.md
@@ -8,8 +8,10 @@ menu:
 weight: 470
 ---
 
-This guide will show you how to use NATS JetStream Object Store as a replica 
-destination for Litestream. You will need a NATS server with JetStream enabled 
+> **⚠️ Note:** NATS JetStream support is available in Litestream v0.5.0+. This feature is not available in v0.3.13.
+
+This guide will show you how to use NATS JetStream Object Store as a replica
+destination for Litestream. You will need a NATS server with JetStream enabled
 to complete this guide.
 
 ## Setup

--- a/content/reference/mcp.md
+++ b/content/reference/mcp.md
@@ -8,7 +8,9 @@ menu:
 weight: 525
 ---
 
-The `mcp` server provides Model Context Protocol integration, allowing AI assistants 
+> **⚠️ Note:** MCP support is available in Litestream v0.5.0+. This feature is not available in v0.3.13.
+
+The `mcp` server provides Model Context Protocol integration, allowing AI assistants
 to interact with Litestream databases and replicas through a standardized HTTP API.
 
 ## Configuration

--- a/content/tips/index.md
+++ b/content/tips/index.md
@@ -118,6 +118,8 @@ is one hour then you will see a rolling set of 24 snapshots for your replica.
 
 ## Disable autocheckpoints for high write load servers
 
+> **Note:** Checkpoint detection improvements in v0.5.0+ reduce the need for full snapshots when checkpoints occur.
+
 By default, SQLite allows any process to perform a checkpoint. A checkpoint is
 when pages that are written to the WAL are copied back to the main database
 file. Litestream works by controlling this checkpointing process and

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,2 +1,2 @@
 params:
-  litestreamVersion: 0.5.0
+  litestreamVersion: 0.3.13


### PR DESCRIPTION
## Summary
- Reverts documentation download links to point to v0.3.13 (latest stable) instead of non-existent v0.5.0
- Adds clear version notices for v0.5.0-only features
- Resolves issue reported on Twitter where users couldn't download v0.5.0

## Context
As discussed with Ben, v0.5.0 hasn't been officially released yet (only test/beta versions exist). The docs were updated to describe v0.5.0 features but still pointed to v0.5.0 downloads, which don't exist. This caused confusion for users trying to install Litestream.

## Changes
- Changed `litestreamVersion` from `0.5.0` to `0.3.13` in `hugo.yaml`
- Added version warning notices to:
  - NATS JetStream replication guide (completely new in v0.5.0)
  - MCP reference documentation (completely new in v0.5.0)  
  - Checkpoint tips section (improved in v0.5.0)

## Test Plan
- [x] Verified version shortcode now outputs v0.3.13
- [x] Checked that download links will point to existing release
- [x] Confirmed v0.5.0 features are clearly marked with version notices

When v0.5.0 is officially released next week, we'll only need to update `hugo.yaml` to switch all download links to the new version.

🤖 Generated with [Claude Code](https://claude.ai/code)