### PR TITLE
Update replica config syntax for 0.5.0

### DIFF
--- a/content/guides/backblaze/index.md
+++ b/content/guides/backblaze/index.md
@@ -30,12 +30,12 @@ the file"_ as Litestream files are immutable and don't require versioning.
 ```yaml
 dbs:
   - path: path-to-your-local-db-file
-    replicas:
-      - type: s3
-        bucket: your-bucket-name
-        path: db # change to whatever path you want
-        endpoint: s3.us-west-000.backblazeb2.com # change this
-        force-path-style: true
+    replica:
+      type: s3
+      bucket: your-bucket-name
+      path: db # change to whatever path you want
+      endpoint: s3.us-west-000.backblazeb2.com # change this
+      force-path-style: true
 ```
 
 ## Create a user
@@ -69,10 +69,10 @@ secret-access-key: your-backblaze-applicationKey
 
 dbs:
   - path: path-to-your-local-db-file
-    replicas:
-      - type: s3
-        bucket: your-bucket-name
-        path: db # change to whatever path you want
-        endpoint: s3.us-west-000.backblazeb2.com # change this
-        force-path-style: true
+    replica:
+      type: s3
+      bucket: your-bucket-name
+      path: db # change to whatever path you want
+      endpoint: s3.us-west-000.backblazeb2.com # change this
+      force-path-style: true
 ```

--- a/content/guides/digitalocean/index.md
+++ b/content/guides/digitalocean/index.md
@@ -95,8 +95,8 @@ secret-access-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxx
 
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - url: s3://SPACENAME.nyc3.digitaloceanspaces.com/db
+    replica:
+      url: s3://SPACENAME.nyc3.digitaloceanspaces.com/db
 ```
 
 Or you can expand your configuration into multiple fields:
@@ -104,12 +104,12 @@ Or you can expand your configuration into multiple fields:
 ```yaml
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - type: s3
-        bucket:   SPACENAME
-        path:     db
-        endpoint: nyc3.digitaloceanspaces.com
-        region:   nyc3   # set to your region
+    replica:
+      type: s3
+      bucket:   SPACENAME
+      path:     db
+      endpoint: nyc3.digitaloceanspaces.com
+      region:   nyc3   # set to your region
 ```
 
 You may also specify your key credentials on a per-replica basis:
@@ -117,10 +117,10 @@ You may also specify your key credentials on a per-replica basis:
 ```yaml
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - url: s3://SPACENAME.nyc3.digitaloceanspaces.com/db
-        access-key-id: xxxxxxxxxxxxxxxxxxx
-        secret-access-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxx
+    replica:
+      url: s3://SPACENAME.nyc3.digitaloceanspaces.com/db
+      access-key-id: xxxxxxxxxxxxxxxxxxx
+      secret-access-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxx
 ```
 
 

--- a/content/guides/docker/index.md
+++ b/content/guides/docker/index.md
@@ -44,8 +44,8 @@ secret-access-key: YOUR_SECRET_ACCESS_KEY
 
 dbs:
   - path: /data/db
-    replicas:
-      - url: s3://BUCKET/db
+    replica:
+      url: s3://BUCKET/db
 ```
 
 Note that the database `path` is using the `/data` path in your Docker container.

--- a/content/guides/kubernetes/index.md
+++ b/content/guides/kubernetes/index.md
@@ -74,8 +74,8 @@ is set up to replicate a database at `/var/lib/myapp/db` to a remote S3 bucket.
 ```yml
 dbs:
   - path: /var/lib/myapp/db
-    replicas:
-      - url: s3://YOURBUCKET/db
+    replica:
+      url: s3://YOURBUCKET/db
 ```
 
 Next, we'll need to add this as a ConfigMap in our Kubernetes cluster:

--- a/content/guides/linode/index.md
+++ b/content/guides/linode/index.md
@@ -97,8 +97,8 @@ secret-access-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxx
 
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - url: s3://BUCKETNAME.us-east-1.linodeobjects.com/db
+    replica:
+      url: s3://BUCKETNAME.us-east-1.linodeobjects.com/db
 ```
 
 Or you can expand your configuration into multiple fields:
@@ -106,12 +106,12 @@ Or you can expand your configuration into multiple fields:
 ```yaml
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - type: s3
-        bucket:   BUCKETNAME
-        path:     db
-        endpoint: https://us-east-1.linodeobjects.com
-        region:   us-east-1   # set to your region
+    replica:
+      type: s3
+      bucket:   BUCKETNAME
+      path:     db
+      endpoint: https://us-east-1.linodeobjects.com
+      region:   us-east-1   # set to your region
 ```
 
 You may also specify your key credentials on a per-replica basis:
@@ -119,10 +119,10 @@ You may also specify your key credentials on a per-replica basis:
 ```yaml
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - url: s3://BUCKETNAME.us-east-1.linodeobjects.com/db
-        access-key-id: xxxxxxxxxxxxxxxxxxx
-        secret-access-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    replica:
+      url: s3://BUCKETNAME.us-east-1.linodeobjects.com/db
+      access-key-id: xxxxxxxxxxxxxxxxxxx
+      secret-access-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 

--- a/content/guides/scaleway/index.md
+++ b/content/guides/scaleway/index.md
@@ -56,14 +56,14 @@ Here is an example `litestream.yml` configuration file. Make sure to specifi the
 ```yaml
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - type: s3
-        bucket: <bucket-name>
-        path: db
-        endpoint: s3.<region>.scw.cloud # e.g. s3.fr-par.scw.cloud
-        region: <region> # e.g. fr-par
-        access-key-id: SCWXXXXXXXXXXXXXXXXX
-        secret-access-key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    replica:
+      type: s3
+      bucket: <bucket-name>
+      path: db
+      endpoint: s3.<region>.scw.cloud # e.g. s3.fr-par.scw.cloud
+      region: <region> # e.g. fr-par
+      access-key-id: SCWXXXXXXXXXXXXXXXXX
+      secret-access-key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 [os]: https://www.scaleway.com/en/object-storage/

--- a/content/guides/sftp/index.md
+++ b/content/guides/sftp/index.md
@@ -45,8 +45,8 @@ file][]. You can configure a replica for your database using the `url` format.
 ```yaml
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - url: sftp://USER:PASSWORD@HOST:PORT/PATH
+    replica:
+      url: sftp://USER:PASSWORD@HOST:PORT/PATH
 ```
 
 Or you can expand your configuration into multiple fields:
@@ -54,12 +54,12 @@ Or you can expand your configuration into multiple fields:
 ```yaml
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - type:     sftp
-        host:     HOST:PORT
-        user:     USER
-        password: PASSWORD
-        path:     PATH
+    replica:
+      type:     sftp
+      host:     HOST:PORT
+      user:     USER
+      password: PASSWORD
+      path:     PATH
 ```
 
 The `path` is treated as a relative path from the present working directory
@@ -71,9 +71,9 @@ file path should point to your private key.
 ```yaml
 dbs:
   - path: /path/to/local/db
-    replicas:
-      - url: sftp://USER@HOST:PORT/PATH
-        key-path: /path/to/id_rsa
+    replica:
+      url: sftp://USER@HOST:PORT/PATH
+      key-path: /path/to/id_rsa
 ```
 
 

--- a/content/guides/systemd/index.md
+++ b/content/guides/systemd/index.md
@@ -65,9 +65,9 @@ secret-access-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxx
 
 dbs:
   - path: /home/MYUSER/friends.db
-    replicas:
-      - url: s3://mybkt.litestream.io/friends.db
-        sync-interval: 1s
+    replica:
+      url: s3://mybkt.litestream.io/friends.db
+      sync-interval: 1s
 EOF
 ```
 


### PR DESCRIPTION
As of 0.5.0, litestream.yml only allows a single replica, so this updates the documentation to match the new litestream.yml semantics.