### PR TITLE
docs: add MinIO configuration and remote server troubleshooting (v0.5)

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -55,6 +55,8 @@ Password: minioadmin
 Next, navigate to "Buckets", click the "Create Bucket" button in the top right corner and then click the
 _"Save"_ icon. Name your bucket, `"mybkt"`.
 
+{{< alert icon="⚠️" text="<strong>For remote MinIO servers:</strong> If your MinIO instance is running on a different machine (not localhost), skip this tutorial. See the <a href=\"/reference/config#minio-configuration\">MinIO Configuration</a> section in the documentation for setup instructions. This tutorial only covers local MinIO running via Docker." >}}
+
 
 ## Setting up your database
 
@@ -170,6 +172,55 @@ apple|red
 banana|yellow
 grape|purple
 ```
+
+
+## Troubleshooting
+
+### "The AWS Access Key Id you provided does not exist in our records"
+
+This error occurs when Litestream cannot authenticate with MinIO. Common causes:
+
+1. **Wrong credentials**: Verify you're using the correct access key and secret key.
+   The default MinIO Docker container uses `minioadmin` / `minioadmin`.
+
+2. **Missing endpoint for remote MinIO**: If your MinIO server is on a different machine,
+   you **must** specify the `endpoint` parameter in your configuration file. See the
+   [MinIO Configuration](/reference/config#minio-configuration) section.
+
+3. **Environment variable conflicts**: Environment variables take precedence over
+   config files. Unset any conflicting environment variables:
+   ```sh
+   unset LITESTREAM_ACCESS_KEY_ID
+   unset LITESTREAM_SECRET_ACCESS_KEY
+   unset AWS_ACCESS_KEY_ID
+   unset AWS_SECRET_ACCESS_KEY
+   ```
+
+### "Cannot lookup region"
+
+This error typically means the region is missing or invalid. For MinIO, any region
+value works (e.g., `us-east-1`) since MinIO ignores this parameter but still
+requires it in the configuration.
+
+### MinIO console shows empty bucket but replicate command ran
+
+Check that you specified the correct bucket name in your replication command. The
+URL format is `s3://BUCKET_NAME.ENDPOINT/PATH`.
+
+For local MinIO: `s3://mybkt.localhost:9000/fruits.db`
+
+For remote MinIO: You need a configuration file with the endpoint parameter—see
+the [MinIO Configuration](/reference/config#minio-configuration) section.
+
+### Changes aren't being replicated
+
+Verify that:
+- Litestream is still running in your terminal window
+- The MinIO instance is still running
+- You can access the MinIO console at the expected address
+
+If using a config file, ensure credentials are correct and the file is being read
+by passing the `-config` flag to Litestream.
 
 
 ## Further reading

--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -248,6 +248,87 @@ The following settings are specific to S3 replicas:
   a local node such as MinIO and you are using self-signed certificates.
 
 
+### MinIO Configuration
+
+MinIO is an S3-compatible object storage service. The main difference from AWS S3
+is that MinIO requires specifying an `endpoint` parameter pointing to your MinIO
+server. Additionally, when using MinIO, you must create access keys in the MinIO
+console before configuring Litestream.
+
+#### Local MinIO (Docker)
+
+For local testing with MinIO running on your machine via Docker, you can use
+command-line environment variables:
+
+```yaml
+access-key-id:     minioadmin
+secret-access-key: minioadmin
+```
+
+Command-line replication to local MinIO:
+
+```sh
+export LITESTREAM_ACCESS_KEY_ID=minioadmin
+export LITESTREAM_SECRET_ACCESS_KEY=minioadmin
+litestream replicate mydb.db s3://mybkt.localhost:9000/mydb.db
+```
+
+#### Remote MinIO Server
+
+For remote MinIO servers, you **must** use a configuration file and specify the
+`endpoint` parameter. Environment variables take precedence over config file
+values, so ensure any conflicting environment variables are unset before running
+Litestream.
+
+Configuration file example with remote MinIO:
+
+```yaml
+dbs:
+  - path: /var/lib/mydb.db
+    replica:
+      type: s3
+      bucket: mybkt
+      path: mydb.db
+      endpoint: https://minio.example.com:9000
+      region: us-east-1
+      access-key-id: myaccesskey
+      secret-access-key: mysecretkey
+```
+
+Or using the URL shorthand form:
+
+```yaml
+dbs:
+  - path: /var/lib/mydb.db
+    replica:
+      url: s3://mybkt/mydb.db
+      endpoint: https://minio.example.com:9000
+      region: us-east-1
+      access-key-id: myaccesskey
+      secret-access-key: mysecretkey
+```
+
+#### Key Points for MinIO Configuration
+
+1. **Endpoint**: Required for non-AWS S3 services. Should be the full URL to your
+   MinIO server (e.g., `https://minio.example.com:9000` or
+   `http://minio.local:9000`).
+
+2. **Region**: While MinIO ignores the region parameter, Litestream still requires
+   it. You can use any value such as `us-east-1`.
+
+3. **Access Keys**: These must be created in the MinIO console before use. The
+   default MinIO installation uses `minioadmin` / `minioadmin` but you should
+   change these credentials in production.
+
+4. **TLS Certificate**: If using self-signed certificates, add `skip-verify: true`
+   to your replica configuration (not recommended for production).
+
+5. **Environment Variables**: Environment variables take precedence over config
+   file values. If you're using a config file with inline credentials, unset any
+   conflicting `LITESTREAM_*` or `AWS_*` environment variables first.
+
+
 ### File replica
 
 File replicas can be configured using the `"path"` field:


### PR DESCRIPTION
## Summary

- Add comprehensive MinIO Configuration section to config reference with local and remote examples
- Document required endpoint parameter for remote MinIO servers
- Explain environment variable precedence and access key creation
- Add troubleshooting section to Getting Started guide for common MinIO errors
- Add warning note about remote MinIO requiring config file approach

Closes #107

## Test plan

- [ ] Verify config documentation renders correctly
- [ ] Check that MinIO configuration examples are clear and complete
- [ ] Confirm troubleshooting section provides helpful guidance
- [ ] Test links to MinIO Configuration section work properly