### PR TITLE
docs: update for dual-version structure and remove Netlify references

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/benbjohnson/litestream/discussions
+    about: Ask questions and discuss Litestream features
+  - name: Litestream Repository
+    url: https://github.com/benbjohnson/litestream
+    about: Report bugs or request features in Litestream itself

--- a/.github/ISSUE_TEMPLATE/documentation-bug.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-bug.yml
@@ -1,0 +1,64 @@
+name: Documentation Bug
+description: Report an error in the documentation (typo, incorrect info, broken link)
+title: "docs: "
+labels: ["documentation", "bug"]
+assignees: []
+
+body:
+  - type: dropdown
+    id: version
+    attributes:
+      label: Affected Version(s)
+      description: Which documentation version(s) are affected?
+      options:
+        - v0.5.x (main branch)
+        - v0.3.x (docs-v0.3 branch)
+        - Both versions
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: verification
+    attributes:
+      label: Verification
+      description: Have you verified this issue applies to the selected version(s)?
+      options:
+        - label: "I have verified this issue exists in the selected version(s)"
+          required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Affected Page/Section
+      description: URL or file path of the affected documentation
+      placeholder: "e.g., https://litestream.io/docs/getting-started/ or content/docs/getting-started/index.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What's Wrong?
+      description: Describe the issue clearly
+      placeholder: "e.g., The configuration example shows the wrong syntax for SFTP_KEY_PASSPHRASE"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Documentation
+      description: What should the documentation say instead?
+      placeholder: "The correct syntax should be..."
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other relevant information (screenshots, related issues, etc.)
+      placeholder: "Add screenshots or links if helpful"
+
+  - type: markdown
+    attributes:
+      value: |
+        **Note:** If this issue applies to both versions, you may need to file separate PRs for each branch. See the README for the dual-version contribution workflow.

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.yml
@@ -1,0 +1,64 @@
+name: Documentation Improvement
+description: Suggest an improvement to existing documentation (clarity, examples, structure)
+title: "docs: "
+labels: ["documentation", "enhancement"]
+assignees: []
+
+body:
+  - type: dropdown
+    id: version
+    attributes:
+      label: Affected Version(s)
+      description: Which documentation version(s) would benefit from this improvement?
+      options:
+        - v0.5.x (main branch)
+        - v0.3.x (docs-v0.3 branch)
+        - Both versions
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Affected Page/Section
+      description: URL or file path of the documentation
+      placeholder: "e.g., https://litestream.io/docs/getting-started/ or content/docs/getting-started/index.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_issue
+    attributes:
+      label: What Could Be Better?
+      description: What's unclear, confusing, or could be improved?
+      placeholder: "e.g., The configuration examples don't show how to handle authentication errors"
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Improvement
+      description: How would you improve this section?
+      placeholder: "e.g., Add an example showing error handling, or restructure the section to follow this order..."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: applies_both
+    attributes:
+      label: Version Compatibility
+      options:
+        - label: "This improvement applies to both v0.3.x and v0.5.x (if selected version is Both)"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Examples, screenshots, or related issues
+      placeholder: "Add any additional context that might help"
+
+  - type: markdown
+    attributes:
+      value: |
+        **Note:** If this improvement applies to both versions, changes should be made to each branch. See the README for the dual-version contribution workflow.

--- a/.github/ISSUE_TEMPLATE/documentation-missing.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-missing.yml
@@ -1,0 +1,62 @@
+name: Missing Documentation
+description: Suggest documentation for a feature or topic that isn't documented
+title: "docs: "
+labels: ["documentation", "enhancement"]
+assignees: []
+
+body:
+  - type: dropdown
+    id: version
+    attributes:
+      label: Affected Version(s)
+      description: Which version(s) should this documentation be added to?
+      options:
+        - v0.5.x (main branch)
+        - v0.3.x (docs-v0.3 branch)
+        - Both versions
+    validations:
+      required: true
+
+  - type: input
+    id: feature
+    attributes:
+      label: Feature/Topic
+      description: What feature or topic needs documentation?
+      placeholder: "e.g., Multi-segment replication, REPLICA_URL environment variable"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_state
+    attributes:
+      label: Current State
+      description: Is this documented anywhere else or partially documented?
+      placeholder: "e.g., This is mentioned in the reference docs but not explained in the guides section"
+
+  - type: textarea
+    id: why_needed
+    attributes:
+      label: Why is This Documentation Needed?
+      description: What use case or confusion would this documentation resolve?
+      placeholder: "e.g., Users often ask how to set up replication to multiple cloud providers without understanding the architecture"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: applies_both
+    attributes:
+      label: Version Compatibility
+      options:
+        - label: "This feature/topic exists in both v0.3.x and v0.5.x (if selected version is Both)"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Links to issues, discussions, or examples that might help
+      placeholder: "Add related issues, discussions, or real-world examples"
+
+  - type: markdown
+    attributes:
+      value: |
+        **Note:** If this applies to both versions, documentation should be created for each branch. See the README for the dual-version contribution workflow.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,64 @@
 litestream.io
 =============
 
-This repository is the Litestream web site built on Hugo & Doks.
+This repository is the Litestream web site built on Hugo & Doks, with documentation for both Litestream v0.5.x and v0.3.x.
 
+## Documentation Versions
+
+This project maintains **two active documentation versions** in separate branches:
+
+- **`main` branch**: v0.5.x documentation (latest stable)
+- **`docs-v0.3` branch**: v0.3.x documentation (maintenance/critical fixes only)
+
+### Significant Differences Between Versions
+
+Configuration format, capabilities, supported platforms, and command-line options differ significantly between v0.3.x and v0.5.x. Always verify that changes apply to the appropriate version(s).
+
+## Contributing
+
+### Before Making Documentation Changes
+
+1. **Identify the change type:**
+   - Bug fix (typo, broken link, clarity issue)
+   - New documentation (missing topic or feature)
+   - Enhancement (improved content or examples)
+   - Version-specific update (differs between v0.3.x and v0.5.x)
+
+2. **Determine which version(s) to update:**
+
+   **Update BOTH branches when:**
+   - Fixing documentation bugs (typos, broken links, etc.)
+   - Documenting general concepts and architecture
+   - Updating platform-specific guides (if feature exists in both versions)
+   - Improving installation instructions (if applicable to both)
+
+   **Update ONLY the appropriate branch when:**
+   - Adding new features (v0.5.x only)
+   - Documenting breaking changes
+   - Writing version-specific configuration or capability docs
+   - Documenting deprecated features
+
+3. **Check for version differences:**
+   - Configuration file format/options
+   - Command-line flags and arguments
+   - Supported platforms and cloud providers
+   - Feature availability
+
+### How to Update Both Versions
+
+1. Create a feature branch from `main` (for v0.5.x changes)
+2. Make changes and create a pull request against `main`
+3. Once merged, switch to `docs-v0.3` branch
+4. Cherry-pick or manually apply the same changes (adjusting for version differences)
+5. Create a pull request against `docs-v0.3`
+6. Reference both PRs in the GitHub issue (e.g., "Fixes #123. Also applies to v0.3: benbjohnson/litestream.io#456")
+
+### GitHub Issue Templates
+
+When filing an issue about documentation:
+- **Select the affected version(s):** v0.5.x, v0.3.x, or Both
+- **Verify applicability:** If both versions are affected, check for version-specific differences
+- **Cross-reference:** If your fix applies to multiple branches, file issues/PRs for each
 
 ## Development
 
@@ -15,13 +71,55 @@ $ npm install
 $ npm run start
 ```
 
+This starts a local Hugo development server with live reload at `http://localhost:1313`.
+
+### Building
+
+To build the production site:
+
+```sh
+$ npm run build
+```
+
+The built site will be in the `public/` directory.
+
+### Testing and Linting
+
+To run all linters:
+
+```sh
+$ npm test
+```
+
+Individual linters:
+
+```sh
+$ npm run lint:markdown  # Lint Markdown content
+$ npm run lint:styles   # Lint SCSS stylesheets
+$ npm run lint:scripts  # Lint JavaScript files
+```
 
 ## Documentation
 
-To add a new documentation page, run:
+### Adding a New Page
+
+To add a new documentation page:
 
 ```sh
-$ hugo new docs/prologue/TITLE/index.md
+$ hugo new docs/section/TITLE/index.md
 ```
+
+Replace `section` with an appropriate section (e.g., `guides`, `reference`, `tips`) and `TITLE` with your page name.
+
+### Content Guidelines
+
+- Use Hugo's built-in markup with Goldmark renderer
+- Code blocks use syntax highlighting with Dracula theme
+- Images should be optimized and placed in appropriate `static/` subdirectories
+- Use Hugo's internal link syntax for cross-references
+
+## Deployment
+
+The main branch (v0.5.x docs) automatically deploys to GitHub Pages when changes are pushed. The docs-v0.3 branch is maintained separately for v0.3.x documentation.
 
 

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -9,31 +9,10 @@ languageCode = "en-US"
 pagerSize = 7
 rssLimit = 10
 
-# add redirects/headers
 [outputs]
-home = ["HTML", "RSS", "REDIRECTS", "HEADERS"]
+home = ["HTML", "RSS"]
 section = ["HTML", "RSS", "SITEMAP"]
 
-# remove .{ext} from text/netlify
-[mediaTypes."text/netlify"]
-suffixes = [""]
-delimiter = ""
-
-# add output format for netlify _redirects
-[outputFormats.REDIRECTS]
-mediaType = "text/netlify"
-baseName = "_redirects"
-isPlainText = true
-notAlternative = true
-
-# add output format for netlify _headers
-[outputFormats.HEADERS]
-mediaType = "text/netlify"
-baseName = "_headers"
-isPlainText = true
-notAlternative = true
-
-# add output format for section sitemap.xml
 [outputFormats.SITEMAP]
 mediaType = "application/xml"
 baseName = "sitemap"

--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -1,9 +1,0 @@
-/*
-  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  X-Content-Type-Options: nosniff
-  X-XSS-Protection: 1; mode=block
-  Content-Security-Policy: default-src 'self'; frame-ancestors https://jamstackthemes.dev; manifest-src 'self'; connect-src 'self'; font-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self'
-  X-Frame-Options: SAMEORIGIN
-  Referrer-Policy: strict-origin
-  Feature-Policy: geolocation 'self'
-  Cache-Control: public, max-age=31536000

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,6 +1,0 @@
-# redirects for Netlify - https://www.netlify.com/docs/redirects/
-{{- range $p := .Site.Pages -}}
-{{- range .Aliases }}
-{{ . }} {{ $p.RelPermalink -}}
-{{- end }}
-{{- end -}}


### PR DESCRIPTION
## Summary

This PR completes the migration from Netlify to GitHub Pages and establishes clear documentation guidelines for managing two active documentation versions (v0.5.x on main, v0.3.x on docs-v0.3).

**Changes:**
- Removes Netlify-specific configuration and templates
- Updates README.md with comprehensive dual-version structure and contribution workflow
- Updates CLAUDE.md with detailed guidance for multi-version changes
- Creates GitHub issue templates to help contributors identify version applicability

## What Changed

### Deleted Files
- `netlify.toml` - Netlify build configuration
- `layouts/index.headers` - Netlify headers template
- `layouts/index.redirects` - Netlify redirects template

### Modified Files
- **README.md**: Added detailed sections on Documentation Versions, Contributing workflow, version differences, and how to update both versions
- **config/_default/config.toml**: Removed Netlify media type and output format definitions
- **CLAUDE.md**: Added Multi-Version Documentation section with comprehensive checklist for developers

### New Files
- `.github/ISSUE_TEMPLATE/documentation-bug.yml` - Template for documentation bugs with version selection
- `.github/ISSUE_TEMPLATE/documentation-missing.yml` - Template for missing documentation
- `.github/ISSUE_TEMPLATE/documentation-improvement.yml` - Template for documentation improvements
- `.github/ISSUE_TEMPLATE/config.yml` - Issue template configuration

## Related Issue
Closes #133

## Test Plan
- [x] README provides clear guidance on dual-version structure
- [x] Issue templates appear when creating new documentation-related issues
- [x] Templates require version selection (v0.5.x, v0.3.x, or Both)
- [x] Config removes Netlify-specific output formats
- [x] Verify site builds without Netlify configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)