### PR TITLE
Updating GCS docs to use `gs://` instead of `gcs://`

### DIFF
--- a/content/guides/gcs/index.md
+++ b/content/guides/gcs/index.md
@@ -82,7 +82,7 @@ file][]. You can configure a replica for your database using the `url` format.
 dbs:
   - path: /path/to/local/db
     replica:
-      url: gcs://BUCKET/PATH
+      url: gs://BUCKET/PATH
 ```
 
 Or you can expand your configuration into multiple fields:
@@ -91,7 +91,7 @@ Or you can expand your configuration into multiple fields:
 dbs:
   - path: /path/to/local/db
     replica:
-      type:   gcs
+      type:   gs
       bucket: BUCKET
       path:   PATH
 ```


### PR DESCRIPTION
https://github.com/benbjohnson/litestream/pull/654 removed support for `gcs://` prefixes in litestream. The documentation on the website is currently out of date, as the litestream 0.5.0+ only allows for `gs://` prefixes.