### PR TITLE
fix(deploy): Build v0.5 docs from main instead of docs-v0.5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,8 @@ jobs:
 
       - name: Build v0.5 (latest) documentation
         run: |
-          git fetch origin docs-v0.5
-          git checkout docs-v0.5
+          git fetch origin main
+          git checkout main
           npm run build
           mkdir -p /tmp/public-combined
           cp -r public/* /tmp/public-combined/


### PR DESCRIPTION
## Summary

Updates the deployment workflow to build v0.5 documentation from the `main` branch instead of the outdated `docs-v0.5` branch.

## Problem

The current deployment workflow fetches and builds from `docs-v0.5`, which is missing **152 lines of critical user documentation** that was added to `main`:

- **MinIO troubleshooting section** (51 lines) - Helps users resolve authentication errors, region lookup issues, and replication problems
- **MinIO configuration guide** (81 lines) - Complete setup documentation for local and remote MinIO servers
- **Foreign key constraints tip** (20 lines) - Best practices for data integrity

These improvements were added in PRs #130 and #131 but never made it to the `docs-v0.5` branch.

## What Changed

- `.github/workflows/deploy.yml`: Changed `git checkout docs-v0.5` to `git checkout main` (lines 22-23)

## Impact

After this PR is merged, the live documentation site will serve the complete, up-to-date v0.5 documentation with all recent improvements.

## Next Steps

After this PR is merged:
1. The `docs-v0.5` branch can be safely deleted (it only contains obsolete Netlify configs)
2. Branch protection should be added for `main` and `docs-v0.3` to prevent accidental deletion

## Verification

Confirmed that `main` has all important content from `docs-v0.5`:
- All version banner configurations ✓
- All documentation content ✓
- Updated GitHub Actions workflow ✓

The only files unique to `docs-v0.5` are obsolete:
- `netlify.toml` - No longer needed (switched to GitHub Pages)
- `layouts/index.headers` - Netlify-specific
- `layouts/index.redirects` - Netlify-specific

🤖 Generated with [Claude Code](https://claude.com/claude-code)