### PR TITLE
docs(s3): add comprehensive S3-compatible providers guide

### DIFF
--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -20,7 +20,6 @@ different platforms.
 
 - [Amazon S3](/guides/s3)
 - [S3-Compatible Services](/guides/s3-compatible)
-- [S3 Advanced Configuration](/guides/s3-advanced)
 - [Azure Blob Storage](/guides/azure)
 - [Backblaze B2](/guides/backblaze)
 - [DigitalOcean Spaces](/guides/digitalocean)

--- a/content/guides/s3-compatible/index.md
+++ b/content/guides/s3-compatible/index.md
@@ -484,8 +484,8 @@ replica:
   concurrency: 10
 ```
 
-See the [S3 Advanced Configuration Guide](/guides/s3-advanced/) for detailed
-tuning recommendations.
+See the [Configuration Reference](/reference/config/#s3-replica) for all
+available S3 replica options.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Add comprehensive guide for using Litestream with S3-compatible storage providers
- Cover configuration for 10 S3-compatible services:
  - MinIO (self-hosted)
  - Backblaze B2
  - Wasabi
  - Cloudflare R2
  - DigitalOcean Spaces
  - Linode Object Storage
  - OCI Object Storage
  - Vultr Object Storage
  - Scaleway Object Storage
  - Filebase (decentralized)
- Include configuration methods (URL and explicit fields)
- Add provider compatibility matrix
- Document advanced configuration options (force-path-style, skip-verify, performance tuning)
- Add troubleshooting section for common issues
- Update guides index with new guide and S3 Advanced Configuration link

Closes #151

## Test plan

- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice