### PR TITLE
docs(sftp): add concurrent writes configuration documentation

### DIFF
--- a/content/guides/sftp/index.md
+++ b/content/guides/sftp/index.md
@@ -77,4 +77,55 @@ dbs:
 ```
 
 
+## Concurrent Writes
+
+By default, Litestream enables concurrent writes for SFTP connections, which
+improves upload throughput by allowing multiple write operations to proceed
+simultaneously.
+
+### Trade-offs
+
+Concurrent writes offer better performance but with a trade-off:
+
+- **Enabled (default)**: Higher throughput during replication, but if an upload
+  fails, Litestream must re-upload the entire file from the beginning.
+
+- **Disabled**: Slightly slower uploads, but failed transfers can resume from
+  the last successfully written chunk.
+
+### When to disable concurrent writes
+
+Consider disabling concurrent writes if you have:
+
+- **Unreliable network connections**: If your connection to the SFTP server
+  frequently drops, disabling concurrent writes allows Litestream to resume
+  interrupted uploads rather than starting over.
+
+- **Very large databases**: For databases several gigabytes in size,
+  re-uploading from scratch after a failure can be costly in terms of time
+  and bandwidth.
+
+- **Bandwidth constraints**: In environments where bandwidth is limited or
+  metered, the ability to resume partial uploads may be more important than
+  raw throughput.
+
+### Configuration
+
+To disable concurrent writes, add the `concurrent-writes` option to your
+configuration:
+
+```yaml
+dbs:
+  - path: /path/to/local/db
+    replica:
+      type:              sftp
+      host:              HOST:PORT
+      user:              USER
+      password:          PASSWORD
+      path:              PATH
+      concurrent-writes: false
+```
+
+The `concurrent-writes` option accepts `true` (default) or `false`.
+
 [configuration file]: /reference/config

--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -439,6 +439,10 @@ The following settings are specific to SFTP replicas:
 - `password`—Password for authentication (not recommended for production)
 - `key-path`—Path to SSH private key file for key-based authentication
 - `path`—Remote path where replica files will be stored
+- `concurrent-writes`—Enables concurrent writes for improved throughput (defaults
+  to `true`). When enabled, failed uploads must restart from the beginning. Set
+  to `false` to allow resuming failed transfers from the last successful chunk.
+  See the [SFTP Guide]({{< ref "sftp" >}}) for guidance on when to disable.
 
 
 ### NATS JetStream Object Store replica


### PR DESCRIPTION
## Summary
- Add new "Concurrent Writes" section to SFTP guide explaining the feature and trade-offs
- Document when to disable concurrent writes (unreliable networks, large databases, bandwidth constraints)
- Add `concurrent-writes` option to SFTP replica settings in configuration reference
- Include configuration examples showing how to disable the feature

Closes #118

## Test plan
- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice