### PR TITLE
docs(reference): document flag ordering for replicate command

### DIFF
--- a/content/reference/replicate.md
+++ b/content/reference/replicate.md
@@ -62,5 +62,5 @@ litestream replicate -exec "myapp serve" /path/to/db s3://mybucket/db
 
 # ❌ Incorrect: flags after positional arguments
 litestream replicate /path/to/db s3://mybucket/db -exec "myapp serve"
-# Error: replica url scheme required: -exec
+# Error: flag "-exec" must be positioned before DB_PATH and REPLICA_URL arguments
 ```


### PR DESCRIPTION
## Summary
- Add warning alert to `replicate` command reference documenting that CLI flags must appear before positional arguments
- Add example showing correct vs incorrect flag placement and the resulting error message

Closes #101

## Test plan
- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice