### PR TITLE
fix(docs): correct GCS URL scheme from gcs:// to gs://

### DIFF
--- a/content/guides/gcs/index.md
+++ b/content/guides/gcs/index.md
@@ -63,14 +63,14 @@ you can replicate a database to your bucket. _Replace the placeholders with your
 bucket & path._
 
 ```sh
-litestream replicate /path/to/db gcs://BUCKET/PATH
+litestream replicate /path/to/db gs://BUCKET/PATH
 ```
 
 You can later restore your database from Google Cloud Storage to a local `my.db`
 path with the following command.
 
 ```sh
-litestream restore -o my.db gcs://BUCKET/PATH
+litestream restore -o my.db gs://BUCKET/PATH
 ```
 
 ### Configuration file usage


### PR DESCRIPTION
## Summary
- Fix incorrect URL scheme in GCS documentation command-line examples
- Changed `gcs://BUCKET/PATH` to `gs://BUCKET/PATH` on lines 66 and 73
- The `gs://` scheme matches the Litestream codebase (`ReplicaClientType = "gs"`)

Closes #176

## Test plan
- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice