### PR TITLE
docs(linode): remove https:// prefix from endpoint example

### DIFF
--- a/content/guides/linode/index.md
+++ b/content/guides/linode/index.md
@@ -110,7 +110,7 @@ dbs:
       - type: s3
         bucket:   BUCKETNAME
         path:     db
-        endpoint: https://us-east-1.linodeobjects.com
+        endpoint: us-east-1.linodeobjects.com
         region:   us-east-1   # set to your region
 ```
 


### PR DESCRIPTION
## Summary
- Remove `https://` prefix from Linode endpoint example to match other S3-compatible provider guides

The Linode guide used `endpoint: https://us-east-1.linodeobjects.com` while all other guides (Backblaze, DigitalOcean, Scaleway) use the endpoint without the prefix (e.g., `endpoint: s3.us-west-000.backblazeb2.com`).

Related to #179 (main branch PR)

Closes #178

## Test plan
- [x] Markdown linting passes (for the Linode guide)
- [ ] Links resolve correctly in local dev server
- [x] Content matches existing style/voice