### PR TITLE
fix(docs): correct broken IAM policy anchor link in S3 guide

### DIFF
--- a/content/guides/s3/index.md
+++ b/content/guides/s3/index.md
@@ -30,7 +30,7 @@ click the _Next_ button.
 
 On the permissions screen, click on _"Attach existing policies directly"_, then
 search for "S3" and choose `AmazonS3FullAccess`. You can also specify a [more
-restrictive policy](#restrictive-iam-policy) as described later in this guide.
+restrictive policy](#restrictive-iam-policies) as described later in this guide.
 
 <figure>
  <img src="iam_1.png" alt="Screenshot of attaching policy to IAM user">


### PR DESCRIPTION
## Summary

Fixes a broken internal link in the S3 replication guide.

The link to the "Restrictive IAM Policies" section was using the singular form `#restrictive-iam-policy` but the actual heading "## Restrictive IAM Policies" generates a plural anchor `#restrictive-iam-policies`.

## Changes

- `content/guides/s3/index.md`: Fix anchor from `#restrictive-iam-policy` → `#restrictive-iam-policies`

## Note

This fix was identified during the review of PR #86. The rest of PR #86's content is now obsolete as PR #184 has already added comprehensive S3-compatible storage documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)