### PR TITLE
fix(config): correct concurrent-writes type from integer to boolean

### DIFF
--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -159,7 +159,7 @@ host: backup.example.com:22
 user: backupuser
 password: ${SFTP_PASSWORD}
 key-path: /etc/litestream/sftp_key
-concurrent-writes: 4
+concurrent-writes: true
 ```
 
 **NATS JetStream settings:**


### PR DESCRIPTION
## Summary
- Fix incorrect `concurrent-writes: 4` example to `concurrent-writes: true`
- The SFTP `concurrent-writes` option is a boolean, not an integer

## Evidence

Litestream rejects integer values:
```
$ ../litestream/litestream replicate -config test.yml
ERROR failed to run error="yaml: unmarshal errors:
  line 9: cannot unmarshal !!int `4` into bool"
```

Source code confirms boolean type:
```go
// cmd/litestream/main.go
ConcurrentWrites *bool  `yaml:"concurrent-writes"`
```

## Related
Found during review of #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)