### PR TITLE
docs(vfs): document pending index behavior and memory implications

### DIFF
--- a/content/reference/vfs.md
+++ b/content/reference/vfs.md
@@ -170,7 +170,9 @@ SELECT litestream_set_time('10 minutes ago');
 - Page fetch retries: up to 6 attempts with backoff for transient network/read errors.
 - Supports SQLite page sizes from 512 to 65536 bytes (auto-detected from LTX headers).
 - Two-index isolation: incoming LTX pages are staged while readers hold locks,
-  then swapped in to keep long-running reads consistent.
+  then swapped in to keep long-running reads consistent. See
+  [How it works: VFS](/how-it-works/vfs/#memory-implications-of-long-held-transactions)
+  for memory considerations with long-held transactions.
 
 
 ## Limitations & constraints


### PR DESCRIPTION
## Summary

- Expand "Two-index transaction isolation" section in how-it-works/vfs.md with detailed explanation of main vs pending index, memory growth tables, and mitigations already in place
- Add new "Transaction duration & memory" section in guides/vfs with practical recommendations, monitoring guidance, and comparison to SQLite's own behavior
- Add cross-reference in reference/vfs.md to the expanded documentation

Key additions:
- Memory implications table with concrete numbers (write rate × duration → pending entries)
- Recommended transaction duration table by workload scenario
- Comparison table to SQLite primary behavior
- "When NOT to use VFS" guidance for heavy analytics workloads
- Cross-references between documentation sections

Closes #188

## Test plan

- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice