### PR TITLE
fix(guides): correct directory-watcher weight for menu ordering

### DIFF
--- a/content/guides/directory-watcher/index.md
+++ b/content/guides/directory-watcher/index.md
@@ -5,7 +5,7 @@ layout: docs
 menu:
   docs:
     parent: "infrastructure-guides"
-weight: 350
+weight: 340
 ---
 
 This guide will show you how to use the directory watcher feature for automatic


### PR DESCRIPTION
## Summary

- Fix weight from 350 to 340 to follow existing infrastructure guides pattern

This was identified during review of #175 but not committed before merge.

| Guide | Weight |
|-------|--------|
| docker | 300 |
| kubernetes | 310 |
| systemd | 320 |
| windows | 330 |
| directory-watcher | 340 ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)