### PR TITLE
docs(s3-compatible): add Tigris to S3-compatible providers guide

### DIFF
--- a/content/guides/s3-compatible/index.md
+++ b/content/guides/s3-compatible/index.md
@@ -392,6 +392,36 @@ dbs:
 
 See the [Scaleway Guide](/guides/scaleway/) for detailed setup instructions.
 
+### Tigris (Fly.io)
+
+[Tigris](https://www.tigrisdata.com/) is Fly.io's globally distributed
+S3-compatible object storage with automatic geographic distribution and
+CDN-like caching.
+
+**Configuration:**
+
+```yaml
+dbs:
+  - path: /path/to/db
+    replica:
+      type: s3
+      bucket: mybucket
+      path: db
+      endpoint: fly.storage.tigris.dev
+      region: auto
+      access-key-id: ${TIGRIS_ACCESS_KEY}
+      secret-access-key: ${TIGRIS_SECRET_KEY}
+```
+
+**Notes:**
+
+- Litestream v0.5.0+ automatically detects Tigris and configures required settings
+- Region should be set to `auto`
+- Objects are automatically distributed globally and cached near requesters
+- Create buckets using `fly storage create` via the Fly CLI
+
+See the [Tigris Guide](/guides/tigris/) for detailed setup instructions.
+
 ### Filebase
 
 [Filebase](https://filebase.com/) provides S3-compatible access to decentralized
@@ -436,6 +466,7 @@ The following table summarizes configuration requirements for each provider:
 | OCI | Yes | `us-east-1` | No | Namespace in endpoint |
 | Vultr | Yes | Yes | No | No request fees |
 | Scaleway | Yes | Yes | No | EU regions |
+| Tigris | Yes | `auto` | No | Auto-detected in v0.5+ |
 | Filebase | Yes | `us-east-1` | No | Decentralized |
 
 ## Advanced Configuration Options


### PR DESCRIPTION
## Summary
- Adds Tigris (Fly.io) section to the S3-compatible providers guide
- Adds Tigris to the Provider Compatibility Matrix table
- Links to the dedicated Tigris guide

Closes #182

## Test plan
- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice