### PR TITLE
docs(vfs): update Go version requirement from 1.25 to 1.24

### DIFF
--- a/content/guides/vfs/index.md
+++ b/content/guides/vfs/index.md
@@ -27,7 +27,7 @@ LTX files.
 
 ## Prerequisites
 
-- Go 1.25+ with CGO enabled (compiler toolchain installed).
+- Go 1.24+ with CGO enabled (compiler toolchain installed).
 - A Litestream-managed replica already syncing to object storage.
 - SQLite clients that support loadable extensions (CLI, Python, etc.) or a Go application built with CGO.
 - Supported page sizes: 512–65536 bytes (auto-detected from LTX headers).

--- a/content/install/source.md
+++ b/content/install/source.md
@@ -33,7 +33,7 @@ binary.
 ### Prerequisites
 
 - CGO toolchain (gcc/clang)
-- Go 1.25+
+- Go 1.24+
 
 ### Build command
 

--- a/content/reference/vfs.md
+++ b/content/reference/vfs.md
@@ -18,7 +18,7 @@ Pre-built binaries are available in
 
 ## Build requirements
 
-- Go 1.25+ with a working CGO toolchain (gcc/clang).
+- Go 1.24+ with a working CGO toolchain (gcc/clang).
 - Build with the VFS & extension tags using the repository Makefile (handles platform flags):
 
 ```sh


### PR DESCRIPTION
## Summary
- Update Go version requirement from 1.25+ to 1.24+ in VFS documentation
- Affected files: `content/install/source.md`, `content/reference/vfs.md`, `content/guides/vfs/index.md`

Closes #190

## Test plan
- [x] Markdown linting passes
- [x] Links resolve correctly in local dev server
- [x] Content matches existing style/voice