### PR TITLE
chore(commands): add Go version verification with GitHub API fallback

### DIFF
--- a/.claude/commands/add-docs.md
+++ b/.claude/commands/add-docs.md
@@ -134,6 +134,20 @@ git checkout -b docs/$ARGUMENTS-<short-description>
 
 ## 6. Implement Documentation
 
+**GO VERSION REQUIREMENT:**
+If the documentation mentions a Go version prerequisite (e.g., in Prerequisites section), verify it matches the litestream `go.mod`:
+
+```bash
+# Try local repo first, fall back to GitHub API
+if [ -f ../litestream/go.mod ]; then
+  grep "^go " ../litestream/go.mod
+else
+  gh api repos/benbjohnson/litestream/contents/go.mod --jq '.content' | base64 -d | grep "^go "
+fi
+```
+
+If `go.mod` says `go 1.24.1`, documentation should say "Go 1.24 or later".
+
 **DATE FORMAT:**
 Use yesterday's date to avoid Hugo's future-date exclusion (timezone differences on build servers can cause today's date to be treated as "future"). The date appears in RSS feeds and OpenGraph meta tags.
 

--- a/.claude/commands/review-docs.md
+++ b/.claude/commands/review-docs.md
@@ -84,7 +84,12 @@ The final report MUST include proof of every verification:
 If the PR mentions a minimum Go version requirement (e.g., "Go 1.21 or later"), verify it matches the litestream `go.mod`:
 
 ```bash
-grep "^go " ../litestream/go.mod
+# Try local repo first, fall back to GitHub API
+if [ -f ../litestream/go.mod ]; then
+  grep "^go " ../litestream/go.mod
+else
+  gh api repos/benbjohnson/litestream/contents/go.mod --jq '.content' | base64 -d | grep "^go "
+fi
 ```
 
 - The documented version MUST match or be compatible with `go.mod`
@@ -127,7 +132,12 @@ rm -rf /tmp/litestream-review
 
 ## Litestream Binary Location
 
-The Litestream source code is at `../litestream` (relative) or `~/projects/benbjohnson/litestream` (absolute).
+The Litestream source code MAY be available at `../litestream` (relative). This is optional - not all contributors will have the repo cloned locally.
+
+**If local repo is not available:**
+- Use `gh api` to fetch files from GitHub (e.g., go.mod for version checks)
+- Use the installed `litestream` binary for command testing
+- Skip tests that require building from source (acknowledge in report)
 
 If testing requires a specific branch or unreleased feature:
 
@@ -680,7 +690,8 @@ $ ../litestream/litestream replicate -config /tmp/litestream-review/litestream.y
 <summary>📋 Go Version Check</summary>
 
 ```
-$ grep "^go " ../litestream/go.mod
+# Local repo or GitHub API fallback
+$ if [ -f ../litestream/go.mod ]; then grep "^go " ../litestream/go.mod; else gh api repos/benbjohnson/litestream/contents/go.mod --jq '.content' | base64 -d | grep "^go "; fi
 go 1.24.1
 ```
 


### PR DESCRIPTION
## Summary

Add Go version verification to both `/add-docs` and `/review-docs` skills to ensure documented Go version requirements match the actual `go.mod` in the litestream repo.

**Key improvement:** Uses GitHub API fallback when local `../litestream` repo is not available, so all contributors can use these skills regardless of their local setup.

## Changes

### review-docs.md
- Add Section 6: Go Version Verification (MANDATORY)
- Add to pre-report verification checklist
- Add Go Version row to verification summary table
- Add evidence section template for Go version checks
- Update "Litestream Binary Location" to clarify local repo is optional
- Add GitHub API fallback pattern

### add-docs.md
- Add Go version verification step in "Implement Documentation" section
- Use same GitHub API fallback pattern

## Test plan

- [x] Skill file syntax is valid
- [ ] Next `/review-docs` run includes Go version check
- [ ] Works without local litestream repo (uses GitHub API)