### PR TITLE
docs(s3): update sign-payload default to true for v0.5.5

### DIFF
--- a/content/docs/troubleshooting.md
+++ b/content/docs/troubleshooting.md
@@ -335,6 +335,35 @@ mcp-addr: ":3002"
    }
    ```
 
+### S3 Signature Errors
+
+**Error**: `SignatureDoesNotMatch` or similar signature mismatch errors
+
+**Solution**:
+
+This error typically occurs with Litestream versions prior to v0.5.5 when using
+AWS S3 or certain S3-compatible providers.
+
+1. **Upgrade to v0.5.5 or later** — The default `sign-payload` setting changed
+   from `false` to `true`, which resolves most signature issues.
+
+2. If you cannot upgrade, explicitly enable payload signing:
+
+   ```yaml
+   dbs:
+     - path: /path/to/db.sqlite
+       replica:
+         url: s3://bucket/path
+         sign-payload: true
+   ```
+
+3. Or via URL query parameter:
+
+   ```yaml
+   replica:
+     url: s3://bucket/path?sign-payload=true
+   ```
+
 ### NATS Connection Issues
 
 **Error**: `connection refused` or `authentication failed`
@@ -666,6 +695,7 @@ CGO_ENABLED=0 go build ./cmd/litestream
 | `database is locked` | No busy timeout set | Add `PRAGMA busy_timeout = 5000;` |
 | `no such file or directory` | Incorrect database path | Verify path exists and permissions |
 | `NoCredentialsProviders` | Missing AWS credentials | Configure AWS credentials |
+| `SignatureDoesNotMatch` | Unsigned payload (pre-v0.5.5) | Upgrade to v0.5.5+ or set `sign-payload: true` |
 | `connection refused` | Service not running | Check if target service is accessible |
 | `yaml: unmarshal errors` | Invalid YAML syntax | Validate configuration file syntax |
 | `bind: address already in use` | Port conflict | Change MCP port or stop conflicting service |

--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -602,9 +602,11 @@ The following settings are specific to S3 replicas:
   networks but use more memory. See the
   [S3 Advanced Configuration Guide]({{< ref "s3-advanced" >}}) for tuning recommendations.
 
-- `sign-payload`—{{< since version="0.5.0" >}} Signs the request payload. Required
-  by some S3-compatible providers like Tigris. Automatically enabled for Tigris
-  endpoints. Defaults to `false`.
+- `sign-payload`—{{< since version="0.5.0" >}} Signs the request payload.
+  {{< since version="0.5.5" >}} Defaults to `true` for compatibility with AWS S3
+  and most S3-compatible providers. Previously defaulted to `false`, which caused
+  `SignatureDoesNotMatch` errors with some configurations. Set to `false` only if
+  your specific provider requires unsigned payloads.
 
 - `require-content-md5`—{{< since version="0.5.0" >}} Adds Content-MD5 header to
   requests. Some S3-compatible providers don't support this header on certain
@@ -624,13 +626,13 @@ for popular providers:
 
 | Provider | sign-payload | require-content-md5 | Notes |
 |----------|--------------|---------------------|-------|
-| AWS S3 | `false` | `true` | Defaults work |
-| Backblaze B2 | `false` | `true` | Defaults work |
+| AWS S3 | `true` | `true` | Defaults work |
+| Backblaze B2 | `true` | `true` | Defaults work |
 | Tigris (Fly.io) | `true` | `false` | Requires signed payloads |
-| OCI Object Storage | `false` | `true` | Requires Content-MD5 |
-| Filebase | `false` | `true` | Defaults work |
-| MinIO | `false` | `true` | Defaults work |
-| DigitalOcean Spaces | `false` | `true` | Defaults work |
+| OCI Object Storage | `true` | `true` | Requires Content-MD5 |
+| Filebase | `true` | `true` | Defaults work |
+| MinIO | `true` | `true` | Defaults work |
+| DigitalOcean Spaces | `true` | `true` | Defaults work |
 
 
 ### Tigris (Fly.io) Configuration


### PR DESCRIPTION
## Summary

- Update config reference to document `sign-payload` default change from `false` to `true` in v0.5.5
- Update S3-compatible provider requirements table with correct defaults
- Add S3 Signature Errors troubleshooting section for `SignatureDoesNotMatch` errors
- Add `SignatureDoesNotMatch` to Common Error Reference table

This change was introduced in litestream PR #913 to fix signature mismatch errors when using AWS S3 and S3-compatible providers.

Closes #209

## Test plan

- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice