### PR TITLE
docs(s3): document aws-chunked encoding fix for S3-compatible providers

### DIFF
--- a/content/docs/troubleshooting.md
+++ b/content/docs/troubleshooting.md
@@ -391,6 +391,23 @@ AWS S3 or certain S3-compatible providers.
          password: pass
    ```
 
+### S3-Compatible Upload Errors
+
+**Error**: `InvalidContentEncoding`, `MalformedTrailerError`, or similar errors
+when uploading to S3-compatible providers
+
+**Solution**:
+
+This error occurs with Litestream versions prior to v0.5.4 when using S3-compatible
+providers (Tigris, Backblaze B2, MinIO, DigitalOcean Spaces, etc.). AWS SDK Go v2
+v1.73.0+ introduced aws-chunked encoding that many providers don't support.
+
+1. **Upgrade to v0.5.4 or later** — Litestream automatically disables aws-chunked
+   encoding for all S3-compatible providers.
+
+2. See the [S3-Compatible Guide](/guides/s3-compatible/#upload-encoding-errors)
+   for more details.
+
 ### Slow Replication
 
 **Symptoms**: High lag between database changes and replica updates
@@ -841,6 +858,8 @@ CGO_ENABLED=0 go build ./cmd/litestream
 | `no such file or directory` | Incorrect database path | Verify path exists and permissions |
 | `NoCredentialsProviders` | Missing AWS credentials | Configure AWS credentials |
 | `SignatureDoesNotMatch` | Unsigned payload (pre-v0.5.5) | Upgrade to v0.5.5+ or set `sign-payload: true` |
+| `InvalidContentEncoding` | aws-chunked encoding (pre-v0.5.4) | Upgrade to v0.5.4+ for S3-compatible providers |
+| `MalformedTrailerError` | aws-chunked encoding (pre-v0.5.4) | Upgrade to v0.5.4+ for S3-compatible providers |
 | `connection refused` | Service not running | Check if target service is accessible |
 | `yaml: unmarshal errors` | Invalid YAML syntax | Validate configuration file syntax |
 | `bind: address already in use` | Port conflict | Change MCP port or stop conflicting service |

--- a/content/guides/s3-compatible/index.md
+++ b/content/guides/s3-compatible/index.md
@@ -35,6 +35,11 @@ provider-specific quirks. The provider examples below show configurations that
 work with both older Litestream versions and v0.5.0+. If you're using v0.5.0+,
 you can omit the `force-path-style` setting for auto-detected providers.
 
+**New in v0.5.4:** Litestream automatically disables `aws-chunked` content
+encoding for all S3-compatible providers. This prevents upload errors
+(`InvalidContentEncoding`, `MalformedTrailerError`) that occurred with AWS SDK
+Go v2 v1.73.0+ when providers don't support trailing checksums.
+
 ## Overview
 
 S3-compatible services implement Amazon's S3 API, enabling tools built for AWS
@@ -597,6 +602,33 @@ available S3 replica options.
 Some providers (notably DigitalOcean Spaces) may reset connections occasionally.
 Litestream handles these automatically through retries. If you see these errors
 but replication continues, no action is needed.
+
+### Upload Encoding Errors
+
+**Symptom:** `InvalidContentEncoding`, `MalformedTrailerError`, or similar errors
+when uploading to S3-compatible providers
+
+**Background:**
+
+AWS SDK Go v2 v1.73.0+ introduced automatic checksum calculation using
+`aws-chunked` content encoding with trailing checksums. Many S3-compatible
+providers don't support this encoding format, causing upload failures.
+
+**Solutions:**
+
+1. **Upgrade to v0.5.4 or later** — Litestream automatically disables aws-chunked
+   encoding for all S3-compatible providers (any endpoint with a custom URL).
+   This is the recommended solution.
+
+2. If you cannot upgrade and experience these errors, you may need to use an
+   older version of Litestream (v0.5.3 or earlier) that doesn't trigger this
+   SDK behavior.
+
+**Affected Providers:**
+
+This issue can affect any S3-compatible provider including Tigris, Backblaze B2,
+MinIO, DigitalOcean Spaces, Scaleway, Filebase, and others. AWS S3 itself is
+not affected as it fully supports aws-chunked encoding.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

- Add note about v0.5.4 aws-chunked encoding fix to S3-compatible guide's Automatic Provider Detection section
- Add "Upload Encoding Errors" troubleshooting section to S3-compatible guide explaining the `InvalidContentEncoding` and `MalformedTrailerError` errors
- Add "S3-Compatible Upload Errors" section to main troubleshooting guide with cross-reference
- Add `InvalidContentEncoding` and `MalformedTrailerError` to Common Error Reference table

This documents the fix from litestream PRs #907 (Tigris) and #919 (all S3-compatible providers) that disabled aws-chunked encoding for providers that don't support it.

Closes #210

## Test plan

- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice