### PR TITLE
docs(troubleshooting): document operations that invalidate tracking state

### DIFF
--- a/content/docs/troubleshooting.md
+++ b/content/docs/troubleshooting.md
@@ -483,6 +483,7 @@ sqlite3 /path/to/db.sqlite "PRAGMA wal_checkpoint(PASSIVE);"
      - path: /path/to/db.sqlite
        monitor-interval: 10s
        replica:
+         # ... (other replica settings)
          sync-interval: 5m
    ```
 
@@ -603,8 +604,9 @@ sqlite3 /tmp/test.db "PRAGMA integrity_check;"
 
 ## Operations That Invalidate Tracking State
 
-Litestream maintains internal tracking state in `.sqlite-litestream` directories
-to efficiently replicate changes. Certain operations can corrupt or invalidate
+Litestream maintains internal tracking state in `.{filename}-litestream` directories
+(e.g., `.db.sqlite-litestream` for a database file named `db.sqlite`) to efficiently
+replicate changes. Certain operations can corrupt or invalidate
 this tracking, leading to high CPU usage, replication errors, or state mismatch
 between local tracking and remote replicas.
 


### PR DESCRIPTION
## Summary
- Add documentation about operations that corrupt Litestream tracking state
- Document symptoms of corrupted state (high CPU, missing LTX errors, state mismatch)
- Provide step-by-step recovery procedure for corrupted tracking state
- Add prevention recommendations (avoid VACUUM, set busy timeout, monitor WAL)
- Enhance existing High CPU Usage section with better diagnosis steps

This documentation is based on the detailed debugging session in benbjohnson/litestream#955.

Closes #215

## Test plan
- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice