### PR TITLE
fix(docs): correct download URLs to v0.5.6

### DIFF
--- a/content/docs/migration.md
+++ b/content/docs/migration.md
@@ -48,10 +48,10 @@ Download and install the new version:
 
 ```bash
 # Download latest stable release (check https://github.com/benbjohnson/litestream/releases)
-wget https://github.com/benbjohnson/litestream/releases/download/v0.5.3/litestream-v0.5.3-linux-amd64.tar.gz
+wget https://github.com/benbjohnson/litestream/releases/download/v0.5.6/litestream-0.5.6-linux-x86_64.tar.gz
 
 # Extract and install
-tar -xzf litestream-v0.5.3-linux-amd64.tar.gz
+tar -xzf litestream-0.5.6-linux-x86_64.tar.gz
 sudo mv litestream /usr/local/bin/
 sudo chmod +x /usr/local/bin/litestream
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,5 +1,5 @@
 params:
-  litestreamVersion: 0.5.3
+  litestreamVersion: 0.5.6
   docsVersion: "0.5"
   versionBanner:
     version: "v0.5.x"


### PR DESCRIPTION
## Summary

- Update migration guide download URLs to v0.5.6 with correct filename format
- Update `litestreamVersion` param in hugo.yaml to 0.5.6

The v0.5.x releases use a different naming convention than v0.3.x:
- No `v` prefix in filename: `litestream-0.5.6` (not `litestream-v0.5.6`)
- Uses `x86_64` instead of `amd64`

The previous URLs were returning 404 errors:
```
# Old (broken):
litestream-v0.5.3-linux-amd64.tar.gz  → 404

# New (correct):
litestream-0.5.6-linux-x86_64.tar.gz  → 302 (success)
```

Fixes #231
Supersedes #232 (which had the correct version but incorrect filename format)

## Test plan

- [x] Verified new URL returns HTTP 302: `curl -sI "https://github.com/benbjohnson/litestream/releases/download/v0.5.6/litestream-0.5.6-linux-x86_64.tar.gz"`
- [x] Confirmed filename matches actual release asset via GitHub API

🤖 Generated with [Claude Code](https://claude.com/claude-code)