### PR TITLE
docs(s3): update URL query parameters and R2 provider defaults

### DIFF
--- a/content/guides/s3-compatible/index.md
+++ b/content/guides/s3-compatible/index.md
@@ -27,7 +27,7 @@ for most providers.
 | MinIO | `*.minio.*` | `sign-payload: true`, `force-path-style: true` |
 | DigitalOcean Spaces | `*.digitaloceanspaces.com` | `sign-payload: true` |
 | Scaleway | `*.scw.cloud` | `sign-payload: true` |
-| Cloudflare R2 | `*.r2.cloudflarestorage.com` | `sign-payload: true` |
+| Cloudflare R2 | `*.r2.cloudflarestorage.com` | `sign-payload: true`, `concurrency: 2` |
 | Tigris | `*.tigris.dev` | `sign-payload: true`, consistency header |
 
 Auto-detection means you can use simpler configurations without worrying about
@@ -247,6 +247,8 @@ dbs:
 - R2 supports both path-style and virtual-hosted style addressing
 - Jurisdiction-specific endpoints available for EU data residency:
   `${ACCOUNT_ID}.eu.r2.cloudflarestorage.com`
+- {{< since version="0.5.8" >}} Litestream automatically sets `concurrency=2`
+  for R2 endpoints to avoid R2's strict concurrent upload limits
 
 ### DigitalOcean Spaces
 

--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -647,11 +647,30 @@ The following settings are specific to S3 replicas:
   requests. Some S3-compatible providers don't support this header on certain
   operations. Automatically disabled for Tigris endpoints. Defaults to `true`.
 
-These options can also be set via URL query parameters:
+- `sse-customer-algorithm`—{{< since version="0.5.8" >}} SSE-C encryption algorithm.
+
+- `sse-customer-key-md5`—{{< since version="0.5.8" >}} Base64-encoded MD5 digest of the SSE-C encryption key.
+
+These options can also be set via URL query parameters. {{< since version="0.5.8" >}}
+Both camelCase and hyphenated forms are accepted:
 
 ```
 s3://bucket/path?sign-payload=true&require-content-md5=false
+s3://bucket/path?signPayload=true&requireContentMD5=false
 ```
+
+**S3 URL query parameter reference:**
+
+| Parameter | Alias | Default | Description |
+|-----------|-------|---------|-------------|
+| `force-path-style` | `forcePathStyle` | `false` | Use path-style URLs |
+| `skip-verify` | `skipVerify` | `false` | Disable TLS verification |
+| `concurrency` | — | `5` | Parallel upload parts |
+| `part-size` | `partSize` | `5MB` | Size of each upload part |
+| `sign-payload` | `signPayload` | `true` | Sign request payload |
+| `require-content-md5` | `requireContentMD5` | `true` | Add Content-MD5 header |
+| `sse-customer-algorithm` | `sseCustomerAlgorithm` | — | SSE-C algorithm |
+| `sse-customer-key-md5` | `sseCustomerKeyMD5` | — | SSE-C key MD5 |
 
 #### S3-Compatible Provider Requirements
 


### PR DESCRIPTION
## Summary
- Add complete S3 URL query parameter reference table with aliases and defaults
- Document new `sse-customer-algorithm` and `sse-customer-key-md5` params
- Note R2 automatic `concurrency=2` default in S3-compatible guide
- Update R2 auto-detection table entry

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)