### PR TITLE
docs(reference): add -level flag to ltx command

### DIFF
--- a/content/reference/ltx.md
+++ b/content/reference/ltx.md
@@ -35,6 +35,11 @@ litestream ltx [arguments] REPLICA_URL
 ## Arguments
 
 ```
+-level LEVEL
+    View LTX files at a specific compaction level.
+    Accepts a level number (0-9) or "all" to show all levels.
+    When set to "all", output includes a level column.
+
 -config PATH
     Specifies the configuration file.
     Defaults to /etc/litestream.yml
@@ -62,6 +67,22 @@ Lists all LTX files for the `/var/lib/db` database but filters by the `s3` repli
 
 ```
 $ litestream ltx -replica s3 /var/lib/db
+```
+
+### View a specific compaction level
+
+List only L0 (uncompacted) LTX files:
+
+```
+$ litestream ltx -level 0 /var/lib/db
+```
+
+### View all compaction levels
+
+List LTX files across all levels (output includes a `level` column):
+
+```
+$ litestream ltx -level all /var/lib/db
 ```
 
 ### Replica URL LTX files


### PR DESCRIPTION
## Summary
- Add `-level LEVEL` to ltx command Arguments section with valid values (0-9 or `all`)
- Add examples for `-level 0` and `-level all` usage

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)