### PR TITLE
docs(restore): document automatic v0.3.x backup restore

### DIFF
--- a/content/docs/migration.md
+++ b/content/docs/migration.md
@@ -82,6 +82,12 @@ litestream version
    - New global configuration sections: `levels`, `snapshot`, `exec`
    - Extended replica configuration options
 
+5. **Transparent v0.3.x Restore** {{< since version="0.5.8" >}}:
+   - `litestream restore` now automatically detects and restores from v0.3.x
+     format backups without any special flags or configuration
+   - Both v0.3.x and LTX formats are compared and the most recent backup is used
+   - See [restore format detection](/reference/restore/#format-detection) for details
+
 #### Migration Steps
 
 1. **Update configuration format**:

--- a/content/reference/restore.md
+++ b/content/reference/restore.md
@@ -261,6 +261,29 @@ fi
 ```
 
 
+## Format Detection
+
+{{< since version="0.5.8" >}} The `restore` command automatically detects whether
+backups are in v0.3.x format or LTX format and restores from whichever has the
+best available data. This works transparently for both file and S3 backends.
+
+| Scenario | Behavior |
+|----------|----------|
+| With `-timestamp` | Uses format with best snapshot before timestamp |
+| Without `-timestamp` | Uses format with most recent backup overall |
+| Only v0.3.x exists | Uses v0.3.x restore |
+| Only LTX exists | Uses LTX restore |
+| Both exist, v0.3.x newer | Uses v0.3.x restore |
+| Both exist, LTX newer | Uses LTX restore |
+
+The `-timestamp` flag works across both formats, selecting the format that
+has the closest snapshot before the requested time.
+
+This eliminates the need for manual format handling when migrating from v0.3.x
+to v0.5.x — simply run `litestream restore` and it will use the best available
+backup regardless of format.
+
+
 ## See Also
 
 - [Configuration Reference](/reference/config) - Complete configuration options


### PR DESCRIPTION
## Summary
- Add "Format Detection" section to restore.md explaining automatic v0.3.x/LTX format selection
- Include behavior table for various scenarios (with/without timestamp, single/both formats)
- Update migration guide to note transparent v0.3.x restore capability

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)