### PR TITLE
docs(metrics): update sync_error_count to reflect init error counting

### DIFF
--- a/content/reference/metrics.md
+++ b/content/reference/metrics.md
@@ -91,8 +91,9 @@ litestream_sync_count{db="/var/lib/myapp.db"} 150
 
 **Type:** Counter
 
-Number of sync errors that have occurred. Monitor this metric for replication
-health—any non-zero growth indicates sync failures.
+Number of errors that have occurred during sync, including database
+initialization failures. Monitor this metric for replication health—any
+non-zero growth indicates issues with the sync process.
 
 ```
 litestream_sync_error_count{db="/var/lib/myapp.db"} 0


### PR DESCRIPTION
## Summary

- Updated the `litestream_sync_error_count` metric description to reflect that it now also counts database initialization failures, not just sync-specific errors
- This change aligns the docs with upstream [litestream#1129](https://github.com/benbjohnson/litestream/pull/1129), which moved the metrics defer block before `db.init()` in `DB.Sync()`

Fixes #263

## Test Plan

- Verified the updated wording accurately describes the broader error counting behavior
- No code changes — documentation-only update