### PR TITLE
docs(reference): document litestream sync command and POST /sync endpoint

### DIFF
--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -17,6 +17,7 @@ The `litestream` commands are:
 - [`litestream mcp`](/reference/mcp) — MCP server for AI assistant integration.
 - [`litestream replicate`](/reference/replicate) — Runs a server to replicate databases.
 - [`litestream restore`](/reference/restore) — Recovers database backup from a replica.
+- [`litestream sync`](/reference/sync) — Forces immediate WAL-to-LTX sync for a database.
 - [`litestream version`](/reference/version) — Prints the binary version.
 - [`litestream wal`](/reference/wal) — List available WAL files for a database (deprecated).
 

--- a/content/reference/ipc.md
+++ b/content/reference/ipc.md
@@ -122,6 +122,53 @@ $ curl --unix-socket /var/run/litestream.sock \
 {"txid":42}
 ```
 
+### POST /sync
+
+Forces an immediate WAL-to-LTX sync for a database. Without `wait`, the sync
+is triggered and the request returns immediately (fire-and-forget). With `wait`
+set to `true`, the request blocks until both local and remote replication
+complete.
+
+**Request body (JSON):**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `path` | Yes | Absolute path to the SQLite database file |
+| `wait` | No | Block until sync completes including remote replication (default: `false`) |
+| `timeout` | No | Maximum wait time in seconds, best-effort (default: `30`) |
+
+**Example (fire-and-forget):**
+
+```bash
+$ curl --unix-socket /var/run/litestream.sock \
+    -X POST http://localhost/sync \
+    -H "Content-Type: application/json" \
+    -d '{"path":"/path/to/my.db"}'
+{"status":"synced_local","path":"/path/to/my.db","txid":42}
+```
+
+**Example (blocking):**
+
+```bash
+$ curl --unix-socket /var/run/litestream.sock \
+    -X POST http://localhost/sync \
+    -H "Content-Type: application/json" \
+    -d '{"path":"/path/to/my.db","wait":true,"timeout":60}'
+{"status":"synced","path":"/path/to/my.db","txid":42}
+```
+
+**Response statuses:**
+
+| Status | Description |
+|--------|-------------|
+| `synced_local` | WAL-to-LTX sync completed (fire-and-forget mode) |
+| `synced` | Full sync including remote replication completed (blocking mode) |
+| `no_change` | Database was already up to date |
+
+**CLI equivalent:** `litestream sync -socket /var/run/litestream.sock /path/to/my.db`
+
+---
+
 ### /debug/pprof/*
 
 Standard Go [pprof](https://pkg.go.dev/net/http/pprof) endpoints for runtime

--- a/content/reference/sync.md
+++ b/content/reference/sync.md
@@ -1,0 +1,88 @@
+---
+title : "Command: sync"
+date: 2026-02-20T00:00:00Z
+layout: docs
+menu:
+  docs:
+    parent: "reference"
+weight: 542
+---
+
+{{< since version="0.5.8" >}} The `sync` command forces an immediate
+WAL-to-LTX sync for a database managed by the Litestream daemon. By default
+it triggers the sync and returns immediately (fire-and-forget). With the
+`-wait` flag it blocks until the sync completes, including remote replication.
+
+The `sync` command communicates with a running `litestream replicate` process
+over the IPC control socket. The daemon must already be running.
+
+
+## Usage
+
+```
+litestream sync [arguments] DB_PATH
+```
+
+
+## Arguments
+
+```
+-socket PATH
+    Path to the control socket.
+    Defaults to /var/run/litestream.sock
+
+-wait
+    Block until sync completes including remote replication.
+    Defaults to false (fire-and-forget).
+
+-timeout SECONDS
+    Maximum time to wait in seconds, best-effort.
+    Defaults to 30.
+```
+
+
+## Behavior
+
+The `sync` command operates in two modes:
+
+- **Fire-and-forget** (default): Triggers WAL-to-LTX conversion and returns
+  immediately. The response status will be `synced_local` if changes were
+  synced, or `no_change` if the database was already up to date.
+
+- **Blocking** (`-wait`): Blocks until both WAL-to-LTX conversion and
+  LTX-to-remote replication complete. The response status will be `synced`
+  when complete, or `no_change` if the database was already up to date.
+
+
+## Examples
+
+### Basic sync
+
+Trigger an immediate sync for a database:
+
+```
+$ litestream sync /path/to/my.db
+```
+
+### Sync and wait for completion
+
+Block until the sync finishes, including remote replication:
+
+```
+$ litestream sync -wait /path/to/my.db
+```
+
+### Sync with custom timeout and socket
+
+Specify a longer timeout and a non-default socket path:
+
+```
+$ litestream sync -wait -timeout 60 -socket /tmp/litestream.sock /path/to/my.db
+```
+
+
+## See Also
+
+- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `POST /sync`
+- [Command: replicate](/reference/replicate) — Start the replication daemon
+- [Configuration Reference](/reference/config) — Complete configuration options


### PR DESCRIPTION
## Summary

- Add new `content/reference/sync.md` command reference page for `litestream sync`
- Document `POST /sync` IPC endpoint in `content/reference/ipc.md`
- Add `litestream sync` to the commands list in `content/reference/_index.md`

The `sync` command and `POST /sync` endpoint were added in upstream [benbjohnson/litestream#1120](https://github.com/benbjohnson/litestream/pull/1120). Documentation covers both fire-and-forget and blocking (`-wait`) modes, all CLI flags, response statuses, and curl examples.

Closes #262

## Test plan

- [ ] `/reference/sync` page renders correctly with version badge, usage, arguments, behavior, examples, and see-also links
- [ ] `/reference/ipc` shows the new `POST /sync` section with request/response tables and curl examples
- [ ] `/reference/` index lists `litestream sync` alphabetically between `restore` and `version`
- [ ] Navigation sidebar shows "Command: sync" under Reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)