### PR TITLE
docs(vfs): document LITESTREAM_HYDRATION_PATH persistence behavior

### DIFF
--- a/content/guides/vfs-hydration/index.md
+++ b/content/guides/vfs-hydration/index.md
@@ -69,7 +69,7 @@ export LITESTREAM_HYDRATION_PATH=/var/lib/litestream/hydrated.db
 
 If `LITESTREAM_HYDRATION_PATH` is not set, hydration uses a temporary file that
 is cleaned up when the VFS closes. Set an explicit path to persist the hydrated
-database across restarts. {{< since version="0.5.8" >}} With a persistent path,
+database across restarts. {{< since version="0.5.9" >}} With a persistent path,
 hydration resumes from where it left off rather than starting from scratch. See
 [Persistence & resume behavior](#persistence--resume-behavior) below.
 
@@ -107,7 +107,7 @@ The transition happens automatically and is transparent to the application.
 
 ### Persistence & resume behavior
 
-{{< since version="0.5.8" >}}
+{{< since version="0.5.9" >}}
 
 When `LITESTREAM_HYDRATION_PATH` is set to an explicit path, the hydrated
 database and its state persist across connection restarts.

--- a/content/how-it-works/vfs.md
+++ b/content/how-it-works/vfs.md
@@ -215,7 +215,7 @@ This ensures the hydrated database stays current without requiring re-hydration.
 
 ### Persistence across restarts
 
-{{< since version="0.5.8" >}} When `LITESTREAM_HYDRATION_PATH` is set, the
+{{< since version="0.5.9" >}} When `LITESTREAM_HYDRATION_PATH` is set, the
 hydration file persists across connection restarts. A companion `.meta` file
 stores the current TXID so the VFS can resume hydration from where it left off
 rather than performing a full restore. If the remote replica's state has

--- a/content/reference/vfs.md
+++ b/content/reference/vfs.md
@@ -159,7 +159,7 @@ for usage details.
 Once hydration completes, all reads are served from the local file instead of
 remote storage.
 
-{{< since version="0.5.8" >}} When `LITESTREAM_HYDRATION_PATH` is set to an
+{{< since version="0.5.9" >}} When `LITESTREAM_HYDRATION_PATH` is set to an
 explicit path, the hydration file persists across connection restarts. A
 companion `.meta` file (e.g. `hydrated.db.meta`) is written alongside the
 hydration file to track the current transaction ID (TXID). On the next open, if


### PR DESCRIPTION
## Summary

- Document the new hydration file persistence behavior introduced in litestream#1125
- Add documentation for the `.meta` companion file that tracks TXID for resume
- Cover edge cases: TXID regression, stale `.meta` file, and temp file mode unchanged

Closes #268

## Changes

- **`content/reference/vfs.md`**: Added `since v0.5.8` note below the hydration configuration table explaining persistence, `.meta` file, and resume behavior
- **`content/guides/vfs-hydration/index.md`**: Expanded configuration note, added "Persistence & resume behavior" subsection with `.meta` file details and edge cases, updated troubleshooting
- **`content/how-it-works/vfs.md`**: Added "Persistence across restarts" subsection in the hydration mechanism section

## Verification

All technical claims were verified against the Litestream source code (`vfs.go`).

### Source Code Accuracy

| Claim | Source Location | Result |
|-------|----------------|--------|
| `.meta` file stores TXID | `vfs.go:864-878` | PASS |
| `.meta` written atomically via temp+rename | `vfs.go:880-926` | PASS |
| Both files present on open triggers resume from TXID | `vfs.go:583-592` | PASS |
| TXID regression truncates stale hydration, triggers full restore | `vfs.go:1298-1313` | PASS |
| `.meta` exists but hydration file missing: `.meta` cleaned up | `vfs.go:595-597` | PASS |

### Hugo Shortcode & Link Verification

| Item | Result |
|------|--------|
| `{{< since version="0.5.8" >}}` format matches 20+ existing uses | PASS |
| Anchor `#persistence--resume-behavior` correct for Hugo/goldmark `&` handling | PASS |
| Cross-link `/guides/vfs-hydration/#persistence--resume-behavior` matches existing patterns | PASS |
| `&` in heading matches existing patterns (4 similar headings in docs) | PASS |

### Environment Variable Consistency

`LITESTREAM_HYDRATION_PATH` verified across 11 existing references — naming and formatting consistent.

### Review Fixes Applied

1. **Wording precision**: Changed "discarded" to "truncated" in the TXID regression edge case to match the actual implementation (`vfs.go` truncates the file to zero bytes rather than deleting it)
2. **Line length**: Wrapped a 358-char troubleshooting bullet into multiple lines for readability, matching the ~100-char style of adjacent bullets

## Test plan

- [x] Hugo build produces no new errors (pre-existing SCSS/bootstrap dependency error is unrelated)
- [x] `{{< since >}}` shortcode format verified against existing usage
- [x] Internal anchor link `#persistence--resume-behavior` verified for Hugo/goldmark generation
- [x] All 5 technical claims verified against `litestream/vfs.go` source
- [x] CI linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)