### PR TITLE
fix(docs): correct sync command version from v0.5.8 to v0.5.9

### DIFF
--- a/content/reference/ipc.md
+++ b/content/reference/ipc.md
@@ -124,7 +124,7 @@ $ curl --unix-socket /var/run/litestream.sock \
 
 ### POST /sync
 
-Forces an immediate WAL-to-LTX sync for a database. Without `wait`, the sync
+{{< since version="0.5.9" >}} Forces an immediate WAL-to-LTX sync for a database. Without `wait`, the sync
 is triggered and the request returns immediately (fire-and-forget). With `wait`
 set to `true`, the request blocks until both local and remote replication
 complete.

--- a/content/reference/sync.md
+++ b/content/reference/sync.md
@@ -8,7 +8,7 @@ menu:
 weight: 542
 ---
 
-{{< since version="0.5.8" >}} The `sync` command forces an immediate
+{{< since version="0.5.9" >}} The `sync` command forces an immediate
 WAL-to-LTX sync for a database managed by the Litestream daemon. By default
 it triggers the sync and returns immediately (fire-and-forget). With the
 `-wait` flag it blocks until the sync completes, including remote replication.


### PR DESCRIPTION
## Summary

- Fix `since` version tag on `sync` command reference page from v0.5.8 to v0.5.9 (the sync command is from litestream#1120, merged after the v0.5.8 release)
- Add missing `since version="0.5.9"` tag to the new `POST /sync` IPC endpoint documentation

## Files Changed

- `content/reference/sync.md` — version tag `0.5.8` → `0.5.9`
- `content/reference/ipc.md` — added `since version="0.5.9"` to `POST /sync` section

## Context

The `sync` command and its IPC endpoint (`feat(ipc): add sync command for on-demand database replication #1120`) were merged to litestream main after the v0.5.8 release. The documentation PRs (#270, #264) incorrectly tagged these as v0.5.8. All other recently merged PRs (#272, #273, #274) already correctly use v0.5.9.

## Test plan

- [ ] Verify `since` shortcode renders correctly on the sync reference page
- [ ] Verify `since` shortcode renders correctly on the IPC reference page

🤖 Generated with [Claude Code](https://claude.com/claude-code)