### PR TITLE
docs(reference): document replicated_txid in sync API response

### DIFF
--- a/content/reference/ipc.md
+++ b/content/reference/ipc.md
@@ -144,7 +144,7 @@ $ curl --unix-socket /var/run/litestream.sock \
     -X POST http://localhost/sync \
     -H "Content-Type: application/json" \
     -d '{"path":"/path/to/my.db"}'
-{"status":"synced_local","path":"/path/to/my.db","txid":42}
+{"status":"synced_local","path":"/path/to/my.db","txid":42,"replicated_txid":0}
 ```
 
 **Example (blocking):**
@@ -154,8 +154,17 @@ $ curl --unix-socket /var/run/litestream.sock \
     -X POST http://localhost/sync \
     -H "Content-Type: application/json" \
     -d '{"path":"/path/to/my.db","wait":true,"timeout":60}'
-{"status":"synced","path":"/path/to/my.db","txid":42}
+{"status":"synced","path":"/path/to/my.db","txid":42,"replicated_txid":42}
 ```
+
+**Response fields:**
+
+| Field | Description |
+|-------|-------------|
+| `status` | Sync status (see table below) |
+| `path` | Absolute path to the database file |
+| `txid` | Current local transaction ID |
+| `replicated_txid` | Transaction ID confirmed replicated to remote storage. Returns `0` in fire-and-forget mode since remote replication is not awaited. |
 
 **Response statuses:**
 

--- a/content/reference/ipc.md
+++ b/content/reference/ipc.md
@@ -144,7 +144,7 @@ $ curl --unix-socket /var/run/litestream.sock \
     -X POST http://localhost/sync \
     -H "Content-Type: application/json" \
     -d '{"path":"/path/to/my.db"}'
-{"status":"synced_local","path":"/path/to/my.db","txid":42,"replicated_txid":0}
+{"status":"synced_local","path":"/path/to/my.db","txid":42,"replicated_txid":40}
 ```
 
 **Example (blocking):**
@@ -164,7 +164,7 @@ $ curl --unix-socket /var/run/litestream.sock \
 | `status` | Sync status (see table below) |
 | `path` | Absolute path to the database file |
 | `txid` | Current local transaction ID |
-| `replicated_txid` | Transaction ID confirmed replicated to remote storage. Returns `0` in fire-and-forget mode since remote replication is not awaited. |
+| `replicated_txid` | Last transaction ID confirmed replicated to remote storage. In fire-and-forget mode, this may lag behind `txid` since the newly synced data has not yet been replicated. |
 
 **Response statuses:**
 

--- a/content/reference/sync.md
+++ b/content/reference/sync.md
@@ -65,13 +65,15 @@ The `sync` command returns JSON output with the following fields:
 | `txid` | Current local transaction ID |
 | `replicated_txid` | Transaction ID confirmed replicated to remote storage |
 
-The `replicated_txid` field indicates the transaction ID that has been durably
-replicated to remote storage:
+The `replicated_txid` field indicates the last transaction ID that has been
+durably replicated to remote storage:
 
 - With `-wait`: Returns the confirmed replicated transaction ID, allowing you
   to verify that writes have been durably replicated to remote storage.
-- Without `-wait`: Returns `0` since remote replication is not awaited in
-  fire-and-forget mode.
+  The value will match `txid` since the command blocks until replication completes.
+- Without `-wait`: Returns the last known replicated position, which may lag
+  behind `txid` since the newly synced data has not yet been replicated to
+  remote storage.
 
 
 ## Examples
@@ -82,7 +84,12 @@ Trigger an immediate sync for a database:
 
 ```
 $ litestream sync /path/to/my.db
-{"status":"synced_local","path":"/path/to/my.db","txid":42,"replicated_txid":0}
+{
+  "status": "synced_local",
+  "path": "/path/to/my.db",
+  "txid": 42,
+  "replicated_txid": 40
+}
 ```
 
 ### Sync and wait for completion
@@ -91,7 +98,12 @@ Block until the sync finishes, including remote replication:
 
 ```
 $ litestream sync -wait /path/to/my.db
-{"status":"synced","path":"/path/to/my.db","txid":42,"replicated_txid":42}
+{
+  "status": "synced",
+  "path": "/path/to/my.db",
+  "txid": 42,
+  "replicated_txid": 42
+}
 ```
 
 ### Sync with custom timeout and socket

--- a/content/reference/sync.md
+++ b/content/reference/sync.md
@@ -54,6 +54,26 @@ The `sync` command operates in two modes:
   when complete, or `no_change` if the database was already up to date.
 
 
+## Output
+
+The `sync` command returns JSON output with the following fields:
+
+| Field | Description |
+|-------|-------------|
+| `status` | Sync status: `synced_local`, `synced`, or `no_change` |
+| `path` | Absolute path to the database file |
+| `txid` | Current local transaction ID |
+| `replicated_txid` | Transaction ID confirmed replicated to remote storage |
+
+The `replicated_txid` field indicates the transaction ID that has been durably
+replicated to remote storage:
+
+- With `-wait`: Returns the confirmed replicated transaction ID, allowing you
+  to verify that writes have been durably replicated to remote storage.
+- Without `-wait`: Returns `0` since remote replication is not awaited in
+  fire-and-forget mode.
+
+
 ## Examples
 
 ### Basic sync
@@ -62,6 +82,7 @@ Trigger an immediate sync for a database:
 
 ```
 $ litestream sync /path/to/my.db
+{"status":"synced_local","path":"/path/to/my.db","txid":42,"replicated_txid":0}
 ```
 
 ### Sync and wait for completion
@@ -70,6 +91,7 @@ Block until the sync finishes, including remote replication:
 
 ```
 $ litestream sync -wait /path/to/my.db
+{"status":"synced","path":"/path/to/my.db","txid":42,"replicated_txid":42}
 ```
 
 ### Sync with custom timeout and socket


### PR DESCRIPTION
## Summary

- Add `replicated_txid` field to sync command output documentation
- Add `replicated_txid` field to IPC `/sync` endpoint response examples
- Document behavior difference between fire-and-forget mode (returns `0`) and blocking mode (returns confirmed replicated TXID)
- Add "Response fields" table to IPC docs for complete field documentation

Closes #277

## Test plan

- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice