### PR TITLE
docs(reference): clarify distinction between replicate and start/stop commands

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -225,6 +225,24 @@ If using a config file, ensure credentials are correct and the file is being rea
 by passing the `-config` flag to Litestream.
 
 
+## A note on `replicate` vs `start`/`stop`
+
+The `litestream replicate` command used above is what **starts the Litestream
+daemon**. This is the command you run (or configure your service manager to run)
+to begin replication.
+
+Litestream also has [`start`](/reference/start) and [`stop`](/reference/stop)
+commands, but these do something different — they are **client commands** that
+tell an already running daemon to begin or stop replicating a specific database.
+They do not start or stop the daemon itself.
+
+| Command | What it does |
+|---------|-------------|
+| `litestream replicate` | Starts the Litestream daemon |
+| `litestream start DB_PATH` | Tells a running daemon to replicate a database |
+| `litestream stop DB_PATH` | Tells a running daemon to stop replicating a database |
+
+
 ## Further reading
 
 Litestream was built to run as a background service that you don't need to worry

--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -234,7 +234,8 @@ to begin replication.
 Litestream also has [`start`](/reference/start) and [`stop`](/reference/stop)
 commands, but these do something different — they are **client commands** that
 tell an already running daemon to begin or stop replicating a specific database.
-They do not start or stop the daemon itself.
+They do not start or stop the daemon itself. They require the daemon's
+[IPC control socket](/reference/ipc) to be enabled in the configuration.
 
 | Command | What it does |
 |---------|-------------|

--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -15,8 +15,10 @@ The `litestream` commands are:
 - [`litestream databases`](/reference/databases) — Lists databases specified in config file.
 - [`litestream ltx`](/reference/ltx) — List available LTX files for a database.
 - [`litestream mcp`](/reference/mcp) — MCP server for AI assistant integration.
-- [`litestream replicate`](/reference/replicate) — Runs a server to replicate databases.
+- [`litestream replicate`](/reference/replicate) — Starts the replication daemon.
 - [`litestream restore`](/reference/restore) — Recovers database backup from a replica.
+- [`litestream start`](/reference/start) — Tells a running daemon to begin replicating a database.
+- [`litestream stop`](/reference/stop) — Tells a running daemon to stop replicating a database.
 - [`litestream sync`](/reference/sync) — Forces immediate WAL-to-LTX sync for a database.
 - [`litestream version`](/reference/version) — Prints the binary version.
 - [`litestream wal`](/reference/wal) — List available WAL files for a database (deprecated).

--- a/content/reference/ipc.md
+++ b/content/reference/ipc.md
@@ -115,7 +115,7 @@ for a database the daemon already knows about.
 | Field | Required | Description |
 |-------|----------|-------------|
 | `path` | Yes | Absolute path to the SQLite database file |
-| `timeout` | No | Maximum time to wait in seconds (default: `30`) |
+| `timeout` | No | Maximum time to wait in seconds (no default; omit to wait indefinitely) |
 
 **Example:**
 
@@ -123,7 +123,7 @@ for a database the daemon already knows about.
 $ curl --unix-socket /var/run/litestream.sock \
     -X POST http://localhost/start \
     -H "Content-Type: application/json" \
-    -d '{"path":"/path/to/my.db"}'
+    -d '{"path":"/path/to/my.db", "timeout":30}'
 {"status":"started","path":"/path/to/my.db"}
 ```
 
@@ -144,7 +144,7 @@ re-enabled with `/start`.
 | Field | Required | Description |
 |-------|----------|-------------|
 | `path` | Yes | Absolute path to the SQLite database file |
-| `timeout` | No | Maximum time to wait in seconds (default: `30`) |
+| `timeout` | No | Maximum time to wait in seconds (no default; omit to wait indefinitely) |
 
 **Example:**
 
@@ -152,7 +152,7 @@ re-enabled with `/start`.
 $ curl --unix-socket /var/run/litestream.sock \
     -X POST http://localhost/stop \
     -H "Content-Type: application/json" \
-    -d '{"path":"/path/to/my.db"}'
+    -d '{"path":"/path/to/my.db", "timeout":30}'
 {"status":"stopped","path":"/path/to/my.db"}
 ```
 

--- a/content/reference/ipc.md
+++ b/content/reference/ipc.md
@@ -77,7 +77,9 @@ $ curl --unix-socket /var/run/litestream.sock \
     -d '{"path":"/path/to/my.db","replica_url":"s3://mybucket/my.db"}'
 ```
 
-**CLI equivalent:** `litestream register -socket /var/run/litestream.sock -replica s3://mybucket/my.db /path/to/my.db`
+**CLI equivalent:** `litestream start -replica s3://mybucket/my.db -socket /var/run/litestream.sock /path/to/my.db`
+
+See [Command: start](/reference/start) for details.
 
 ---
 
@@ -100,7 +102,9 @@ $ curl --unix-socket /var/run/litestream.sock \
     -d '{"path":"/path/to/my.db"}'
 ```
 
-**CLI equivalent:** `litestream unregister -socket /var/run/litestream.sock /path/to/my.db`
+**CLI equivalent:** `litestream stop -socket /var/run/litestream.sock /path/to/my.db`
+
+See [Command: stop](/reference/stop) for details.
 
 ---
 

--- a/content/reference/ipc.md
+++ b/content/reference/ipc.md
@@ -77,9 +77,7 @@ $ curl --unix-socket /var/run/litestream.sock \
     -d '{"path":"/path/to/my.db","replica_url":"s3://mybucket/my.db"}'
 ```
 
-**CLI equivalent:** `litestream start -replica s3://mybucket/my.db -socket /var/run/litestream.sock /path/to/my.db`
-
-See [Command: start](/reference/start) for details.
+**CLI equivalent:** `litestream register -socket /var/run/litestream.sock -replica s3://mybucket/my.db /path/to/my.db`
 
 ---
 
@@ -100,6 +98,62 @@ $ curl --unix-socket /var/run/litestream.sock \
     -X POST http://localhost/unregister \
     -H "Content-Type: application/json" \
     -d '{"path":"/path/to/my.db"}'
+```
+
+**CLI equivalent:** `litestream unregister -socket /var/run/litestream.sock /path/to/my.db`
+
+---
+
+### POST /start
+
+Enables replication for a database that is already configured in the daemon.
+Unlike `/register`, which adds a new database, `/start` enables replication
+for a database the daemon already knows about.
+
+**Request body (JSON):**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `path` | Yes | Absolute path to the SQLite database file |
+| `timeout` | No | Maximum time to wait in seconds (default: `30`) |
+
+**Example:**
+
+```bash
+$ curl --unix-socket /var/run/litestream.sock \
+    -X POST http://localhost/start \
+    -H "Content-Type: application/json" \
+    -d '{"path":"/path/to/my.db"}'
+{"status":"started","path":"/path/to/my.db"}
+```
+
+**CLI equivalent:** `litestream start -socket /var/run/litestream.sock /path/to/my.db`
+
+See [Command: start](/reference/start) for details.
+
+---
+
+### POST /stop
+
+Disables replication for a database. The daemon performs a final sync before
+disabling. The database remains in the daemon's configuration and can be
+re-enabled with `/start`.
+
+**Request body (JSON):**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `path` | Yes | Absolute path to the SQLite database file |
+| `timeout` | No | Maximum time to wait in seconds (default: `30`) |
+
+**Example:**
+
+```bash
+$ curl --unix-socket /var/run/litestream.sock \
+    -X POST http://localhost/stop \
+    -H "Content-Type: application/json" \
+    -d '{"path":"/path/to/my.db"}'
+{"status":"stopped","path":"/path/to/my.db"}
 ```
 
 **CLI equivalent:** `litestream stop -socket /var/run/litestream.sock /path/to/my.db`

--- a/content/reference/replicate.md
+++ b/content/reference/replicate.md
@@ -9,9 +9,13 @@ weight: 530
 ---
 
 The `replicate` command starts a server to monitor & continuously replicate
-SQLite databases. You can specify your database & replica in a configuration
-file or you can replicate a single database file by specifying its path and its
-replica in the command line arguments.
+SQLite databases. This is the main Litestream daemon — it runs in the
+foreground and replicates databases until it is stopped. You can specify your
+database & replica in a configuration file or you can replicate a single
+database file by specifying its path and its replica in the command line
+arguments.
+
+{{< alert icon="💡" text="<strong><code>replicate</code> vs <code>start</code>/<code>stop</code>:</strong> The <code>replicate</code> command starts the Litestream daemon process. The <a href=\"/reference/start\"><code>start</code></a> and <a href=\"/reference/stop\"><code>stop</code></a> commands are <em>client</em> commands that tell a running daemon to begin or stop replicating a specific database. If you want to launch Litestream, use <code>replicate</code>." >}}
 
 
 ## Usage
@@ -179,6 +183,8 @@ litestream replicate /path/to/db s3://mybucket/db -exec "myapp serve"
 
 ## See Also
 
+- [Command: start](/reference/start) — Tell a running daemon to begin replicating a database
+- [Command: stop](/reference/stop) — Tell a running daemon to stop replicating a database
 - [Configuration Reference](/reference/config) - Complete configuration options
 - [Troubleshooting](/docs/troubleshooting) - Common issues and solutions
 - [Getting Started](/getting-started) - Tutorial for setting up replication

--- a/content/reference/start.md
+++ b/content/reference/start.md
@@ -8,7 +8,7 @@ menu:
 weight: 535
 ---
 
-{{< since version="0.5.8" >}} The `start` command tells a running Litestream
+{{< since version="0.5.7" >}} The `start` command tells a running Litestream
 daemon to enable replication for a specific database. It communicates with the
 `litestream replicate` process over the IPC control socket.
 
@@ -21,8 +21,17 @@ daemon to enable replication for a specific database. It communicates with the
 litestream start [arguments] DB_PATH
 ```
 
-The daemon must already be running via [`litestream replicate`](/reference/replicate).
-If no daemon is running, the command will fail with a connection error.
+The daemon must already be running via [`litestream replicate`](/reference/replicate)
+with the IPC control socket enabled. If the socket is not enabled or no daemon is
+running, the command will fail with a connection error.
+
+To enable the control socket, add this to your configuration file:
+
+```yaml
+socket:
+  enabled: true
+  path: /var/run/litestream.sock
+```
 
 
 ## Arguments

--- a/content/reference/start.md
+++ b/content/reference/start.md
@@ -9,10 +9,10 @@ weight: 535
 ---
 
 {{< since version="0.5.8" >}} The `start` command tells a running Litestream
-daemon to begin replicating a specific database. It communicates with the
+daemon to enable replication for a specific database. It communicates with the
 `litestream replicate` process over the IPC control socket.
 
-{{< alert icon="⚠️" text="<strong>Looking to start the Litestream daemon?</strong> The <code>start</code> command does <em>not</em> start the daemon. Use <a href=\"/reference/replicate\"><code>litestream replicate</code></a> to start the replication daemon. The <code>start</code> command only registers a new database with an <em>already running</em> daemon." >}}
+{{< alert icon="⚠️" text="<strong>Looking to start the Litestream daemon?</strong> The <code>start</code> command does <em>not</em> start the daemon. Use <a href=\"/reference/replicate\"><code>litestream replicate</code></a> to start the replication daemon. The <code>start</code> command only enables replication for a database that is already configured in the daemon." >}}
 
 
 ## Usage
@@ -28,8 +28,9 @@ If no daemon is running, the command will fail with a connection error.
 ## Arguments
 
 ```
--replica URL
-    Replica destination URL (e.g. s3://bucket/path).
+-timeout SECONDS
+    Maximum time to wait in seconds.
+    Defaults to 30.
 
 -socket PATH
     Path to the control socket.
@@ -41,25 +42,25 @@ If no daemon is running, the command will fail with a connection error.
 
 ### Start replicating a database
 
-Tell the running daemon to begin replicating a database to S3:
+Tell the running daemon to enable replication for a database:
 
 ```bash
-$ litestream start -replica s3://mybucket/my.db /path/to/my.db
+$ litestream start /path/to/my.db
 ```
 
-### Use a custom socket path
+### Use a custom socket path and timeout
 
 ```bash
-$ litestream start -replica s3://mybucket/my.db -socket /tmp/litestream.sock /path/to/my.db
+$ litestream start -timeout 60 -socket /tmp/litestream.sock /path/to/my.db
 ```
 
 
 ## How it works
 
 The `start` command sends a request to the daemon's IPC control socket
-(`POST /register`) to dynamically add a database to the daemon's replication
-set. This allows you to add databases without restarting the daemon or
-modifying the configuration file.
+(`POST /start`) to enable replication for a configured database. The database
+must already be known to the daemon — either from the configuration file or
+from a prior [`register`](/reference/ipc#post-register) call.
 
 To later stop replicating the database, use [`litestream stop`](/reference/stop).
 
@@ -69,4 +70,4 @@ To later stop replicating the database, use [`litestream stop`](/reference/stop)
 - [Command: replicate](/reference/replicate) — Start the replication daemon
 - [Command: stop](/reference/stop) — Stop replicating a specific database
 - [Command: sync](/reference/sync) — Force an immediate sync for a database
-- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `POST /register`
+- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `POST /start`

--- a/content/reference/start.md
+++ b/content/reference/start.md
@@ -1,0 +1,72 @@
+---
+title : "Command: start"
+date: 2026-03-23T00:00:00Z
+layout: docs
+menu:
+  docs:
+    parent: "reference"
+weight: 535
+---
+
+{{< since version="0.5.8" >}} The `start` command tells a running Litestream
+daemon to begin replicating a specific database. It communicates with the
+`litestream replicate` process over the IPC control socket.
+
+{{< alert icon="⚠️" text="<strong>Looking to start the Litestream daemon?</strong> The <code>start</code> command does <em>not</em> start the daemon. Use <a href=\"/reference/replicate\"><code>litestream replicate</code></a> to start the replication daemon. The <code>start</code> command only registers a new database with an <em>already running</em> daemon." >}}
+
+
+## Usage
+
+```
+litestream start [arguments] DB_PATH
+```
+
+The daemon must already be running via [`litestream replicate`](/reference/replicate).
+If no daemon is running, the command will fail with a connection error.
+
+
+## Arguments
+
+```
+-replica URL
+    Replica destination URL (e.g. s3://bucket/path).
+
+-socket PATH
+    Path to the control socket.
+    Defaults to /var/run/litestream.sock
+```
+
+
+## Examples
+
+### Start replicating a database
+
+Tell the running daemon to begin replicating a database to S3:
+
+```bash
+$ litestream start -replica s3://mybucket/my.db /path/to/my.db
+```
+
+### Use a custom socket path
+
+```bash
+$ litestream start -replica s3://mybucket/my.db -socket /tmp/litestream.sock /path/to/my.db
+```
+
+
+## How it works
+
+The `start` command sends a request to the daemon's IPC control socket
+(`POST /register`) to dynamically add a database to the daemon's replication
+set. This allows you to add databases without restarting the daemon or
+modifying the configuration file.
+
+To later stop replicating the database, use [`litestream stop`](/reference/stop).
+
+
+## See Also
+
+- [Command: replicate](/reference/replicate) — Start the replication daemon
+- [Command: stop](/reference/stop) — Stop replicating a specific database
+- [Command: sync](/reference/sync) — Force an immediate sync for a database
+- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `POST /register`

--- a/content/reference/stop.md
+++ b/content/reference/stop.md
@@ -1,0 +1,69 @@
+---
+title : "Command: stop"
+date: 2026-03-23T00:00:00Z
+layout: docs
+menu:
+  docs:
+    parent: "reference"
+weight: 537
+---
+
+{{< since version="0.5.8" >}} The `stop` command tells a running Litestream
+daemon to stop replicating a specific database. It communicates with the
+`litestream replicate` process over the IPC control socket.
+
+{{< alert icon="⚠️" text="<strong>This does not stop the Litestream daemon.</strong> To stop the daemon itself, terminate the <a href=\"/reference/replicate\"><code>litestream replicate</code></a> process (e.g. via <code>systemctl stop litestream</code> or <code>Ctrl-C</code>). The <code>stop</code> command only unregisters a single database from an <em>already running</em> daemon." >}}
+
+
+## Usage
+
+```
+litestream stop [arguments] DB_PATH
+```
+
+The daemon must already be running via [`litestream replicate`](/reference/replicate).
+If no daemon is running, the command will fail with a connection error.
+
+
+## Arguments
+
+```
+-socket PATH
+    Path to the control socket.
+    Defaults to /var/run/litestream.sock
+```
+
+
+## Examples
+
+### Stop replicating a database
+
+Tell the running daemon to stop replicating a database:
+
+```bash
+$ litestream stop /path/to/my.db
+```
+
+### Use a custom socket path
+
+```bash
+$ litestream stop -socket /tmp/litestream.sock /path/to/my.db
+```
+
+
+## How it works
+
+The `stop` command sends a request to the daemon's IPC control socket
+(`POST /unregister`) to dynamically remove a database from the daemon's
+replication set. The daemon continues running and replicating any remaining
+databases.
+
+To later resume replication, use [`litestream start`](/reference/start).
+
+
+## See Also
+
+- [Command: replicate](/reference/replicate) — Start the replication daemon
+- [Command: start](/reference/start) — Start replicating a specific database
+- [Command: sync](/reference/sync) — Force an immediate sync for a database
+- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `POST /unregister`

--- a/content/reference/stop.md
+++ b/content/reference/stop.md
@@ -9,10 +9,10 @@ weight: 537
 ---
 
 {{< since version="0.5.8" >}} The `stop` command tells a running Litestream
-daemon to stop replicating a specific database. It communicates with the
+daemon to disable replication for a specific database. It communicates with the
 `litestream replicate` process over the IPC control socket.
 
-{{< alert icon="⚠️" text="<strong>This does not stop the Litestream daemon.</strong> To stop the daemon itself, terminate the <a href=\"/reference/replicate\"><code>litestream replicate</code></a> process (e.g. via <code>systemctl stop litestream</code> or <code>Ctrl-C</code>). The <code>stop</code> command only unregisters a single database from an <em>already running</em> daemon." >}}
+{{< alert icon="⚠️" text="<strong>This does not stop the Litestream daemon.</strong> To stop the daemon itself, terminate the <a href=\"/reference/replicate\"><code>litestream replicate</code></a> process (e.g. via <code>systemctl stop litestream</code> or <code>Ctrl-C</code>). The <code>stop</code> command only disables replication for a single database on an <em>already running</em> daemon." >}}
 
 
 ## Usage
@@ -23,11 +23,16 @@ litestream stop [arguments] DB_PATH
 
 The daemon must already be running via [`litestream replicate`](/reference/replicate).
 If no daemon is running, the command will fail with a connection error.
+The `stop` command always waits for shutdown and a final sync before returning.
 
 
 ## Arguments
 
 ```
+-timeout SECONDS
+    Maximum time to wait in seconds.
+    Defaults to 30.
+
 -socket PATH
     Path to the control socket.
     Defaults to /var/run/litestream.sock
@@ -38,25 +43,26 @@ If no daemon is running, the command will fail with a connection error.
 
 ### Stop replicating a database
 
-Tell the running daemon to stop replicating a database:
+Tell the running daemon to disable replication for a database:
 
 ```bash
 $ litestream stop /path/to/my.db
 ```
 
-### Use a custom socket path
+### Use a custom socket path and timeout
 
 ```bash
-$ litestream stop -socket /tmp/litestream.sock /path/to/my.db
+$ litestream stop -timeout 60 -socket /tmp/litestream.sock /path/to/my.db
 ```
 
 
 ## How it works
 
 The `stop` command sends a request to the daemon's IPC control socket
-(`POST /unregister`) to dynamically remove a database from the daemon's
-replication set. The daemon continues running and replicating any remaining
-databases.
+(`POST /stop`) to disable replication for a database. The daemon performs a
+final sync before disabling, then continues running and replicating any
+remaining databases. The database remains in the daemon's configuration and
+can be re-enabled later.
 
 To later resume replication, use [`litestream start`](/reference/start).
 
@@ -66,4 +72,4 @@ To later resume replication, use [`litestream start`](/reference/start).
 - [Command: replicate](/reference/replicate) — Start the replication daemon
 - [Command: start](/reference/start) — Start replicating a specific database
 - [Command: sync](/reference/sync) — Force an immediate sync for a database
-- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `POST /unregister`
+- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `POST /stop`

--- a/content/reference/stop.md
+++ b/content/reference/stop.md
@@ -8,7 +8,7 @@ menu:
 weight: 537
 ---
 
-{{< since version="0.5.8" >}} The `stop` command tells a running Litestream
+{{< since version="0.5.7" >}} The `stop` command tells a running Litestream
 daemon to disable replication for a specific database. It communicates with the
 `litestream replicate` process over the IPC control socket.
 
@@ -21,8 +21,18 @@ daemon to disable replication for a specific database. It communicates with the
 litestream stop [arguments] DB_PATH
 ```
 
-The daemon must already be running via [`litestream replicate`](/reference/replicate).
-If no daemon is running, the command will fail with a connection error.
+The daemon must already be running via [`litestream replicate`](/reference/replicate)
+with the IPC control socket enabled. If the socket is not enabled or no daemon is
+running, the command will fail with a connection error.
+
+To enable the control socket, add this to your configuration file:
+
+```yaml
+socket:
+  enabled: true
+  path: /var/run/litestream.sock
+```
+
 The `stop` command always waits for shutdown and a final sync before returning.
 
 


### PR DESCRIPTION
## Summary

- Add new reference pages for `litestream start` and `litestream stop` client commands, documenting their usage, arguments, and relationship to the IPC control socket
- Add prominent disambiguation note to the `replicate` reference page explaining it starts the daemon, while `start`/`stop` are client commands
- Add a "replicate vs start/stop" comparison table to the Getting Started guide
- Update the command index and IPC endpoint docs to reference the new pages

Fixes #284

## Test Plan

- Verified `hugo` builds successfully with no errors
- Confirmed `public/reference/start/index.html` and `public/reference/stop/index.html` are generated
- Reviewed all cross-links between pages for consistency