### PR TITLE
docs(reference): document daemon control commands

### DIFF
--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -22,6 +22,19 @@ The `litestream` commands are:
 - [`litestream wal`](/reference/wal) — List available WAL files for a database (deprecated).
 
 
+## Daemon Control Commands
+
+These commands communicate with a running `litestream replicate` daemon over the
+IPC control socket. They require a running daemon with the socket enabled.
+
+- [`litestream info`](/reference/info) — Shows daemon version, PID, and uptime.
+- [`litestream list`](/reference/list) — Lists databases managed by the daemon.
+- [`litestream register`](/reference/register) — Dynamically adds a database to the daemon.
+- [`litestream unregister`](/reference/unregister) — Removes a database from the daemon.
+- [`litestream start`](/reference/start) — Resumes replication for a stopped database.
+- [`litestream stop`](/reference/stop) — Pauses replication for a database.
+
+
 ## VFS Extension
 
 - [`litestream-vfs`](/reference/vfs) — Optional read-only VFS that serves replicas directly from object storage.

--- a/content/reference/info.md
+++ b/content/reference/info.md
@@ -1,0 +1,104 @@
+---
+title : "Command: info"
+date: 2026-05-28T00:00:00Z
+layout: docs
+menu:
+  docs:
+    parent: "reference"
+weight: 543
+---
+
+{{< since version="0.5.12" >}} The `info` command displays information about a
+running Litestream daemon, including version, process ID, uptime, and the number
+of databases being managed.
+
+The `info` command communicates with a running `litestream replicate` process
+over the IPC control socket. The daemon must already be running.
+
+
+## Usage
+
+```
+litestream info [arguments]
+```
+
+
+## Arguments
+
+```
+-socket PATH
+    Path to the control socket.
+    Defaults to /var/run/litestream.sock
+
+-timeout SECONDS
+    Maximum time to wait in seconds.
+    Defaults to 10.
+
+-json
+    Output raw JSON instead of human-readable text.
+```
+
+
+## Output
+
+By default, the `info` command displays daemon information in a human-readable
+format:
+
+```
+$ litestream info
+Litestream v0.5.12
+  PID:        12345
+  Uptime:     1h30m0s
+  Started at: 2026-05-28T10:00:00Z
+  Databases:  3
+```
+
+With the `-json` flag, it returns a JSON object:
+
+| Field | Description |
+|-------|-------------|
+| `version` | Litestream version string |
+| `pid` | Process ID of the daemon |
+| `uptime_seconds` | Daemon uptime in seconds |
+| `started_at` | ISO 8601 timestamp of when the daemon started |
+| `database_count` | Number of databases currently managed |
+
+
+## Examples
+
+### Basic daemon info
+
+```
+$ litestream info
+Litestream v0.5.12
+  PID:        12345
+  Uptime:     1h30m0s
+  Started at: 2026-05-28T10:00:00Z
+  Databases:  3
+```
+
+### JSON output
+
+```
+$ litestream info -json
+{
+  "version": "v0.5.12",
+  "pid": 12345,
+  "uptime_seconds": 5400,
+  "started_at": "2026-05-28T10:00:00Z",
+  "database_count": 3
+}
+```
+
+### Custom socket path
+
+```
+$ litestream info -socket /tmp/litestream.sock
+```
+
+
+## See Also
+
+- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `GET /info`
+- [Command: list](/reference/list) — List all managed databases
+- [Command: replicate](/reference/replicate) — Start the replication daemon

--- a/content/reference/list.md
+++ b/content/reference/list.md
@@ -1,0 +1,125 @@
+---
+title : "Command: list"
+date: 2026-05-28T00:00:00Z
+layout: docs
+menu:
+  docs:
+    parent: "reference"
+weight: 544
+---
+
+{{< since version="0.5.12" >}} The `list` command displays all databases
+currently managed by a running Litestream daemon, along with their replication
+status and last sync time.
+
+The `list` command communicates with a running `litestream replicate` process
+over the IPC control socket. The daemon must already be running.
+
+
+## Usage
+
+```
+litestream list [arguments]
+```
+
+
+## Arguments
+
+```
+-socket PATH
+    Path to the control socket.
+    Defaults to /var/run/litestream.sock
+
+-timeout SECONDS
+    Maximum time to wait in seconds.
+    Defaults to 10.
+
+-json
+    Output raw JSON instead of human-readable text.
+```
+
+
+## Output
+
+By default, the `list` command displays databases in a human-readable format
+showing the path, status, and last sync time:
+
+```
+$ litestream list
+/var/lib/app.db [replicating] (last sync: 2026-05-28T10:30:00Z)
+/var/lib/users.db [replicating] (last sync: 2026-05-28T10:29:45Z)
+```
+
+With the `-json` flag, it returns a JSON object with a `databases` array:
+
+| Field | Description |
+|-------|-------------|
+| `databases` | Array of database summary objects |
+
+Each database summary contains:
+
+| Field | Description |
+|-------|-------------|
+| `path` | Absolute path to the database file |
+| `status` | Current status: `replicating`, `open`, or `stopped` |
+| `last_sync_at` | ISO 8601 timestamp of last successful sync (omitted if never synced) |
+
+
+## Database Status Values
+
+| Status | Description |
+|--------|-------------|
+| `replicating` | Database is open with active replication monitoring |
+| `open` | Database is open but replication monitoring is disabled |
+| `stopped` | Replication for this database has been stopped |
+
+
+## Examples
+
+### List all databases
+
+```
+$ litestream list
+/var/lib/app.db [replicating] (last sync: 2026-05-28T10:30:00Z)
+/var/lib/users.db [replicating] (last sync: 2026-05-28T10:29:45Z)
+```
+
+### JSON output
+
+```
+$ litestream list -json
+{
+  "databases": [
+    {
+      "path": "/var/lib/app.db",
+      "status": "replicating",
+      "last_sync_at": "2026-05-28T10:30:00Z"
+    },
+    {
+      "path": "/var/lib/users.db",
+      "status": "replicating",
+      "last_sync_at": "2026-05-28T10:29:45Z"
+    }
+  ]
+}
+```
+
+### Empty database list
+
+```
+$ litestream list
+No databases configured
+```
+
+### Custom socket path
+
+```
+$ litestream list -socket /tmp/litestream.sock
+```
+
+
+## See Also
+
+- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `GET /list`
+- [Command: info](/reference/info) — Show daemon information
+- [Command: databases](/reference/databases) — List databases from config file (offline)

--- a/content/reference/register.md
+++ b/content/reference/register.md
@@ -1,0 +1,134 @@
+---
+title : "Command: register"
+date: 2026-05-28T00:00:00Z
+layout: docs
+menu:
+  docs:
+    parent: "reference"
+weight: 546
+---
+
+{{< since version="0.5.12" >}} The `register` command dynamically adds a
+database to a running Litestream daemon without requiring a restart. This
+enables runtime database management for applications that create databases
+on-the-fly.
+
+The `register` command communicates with a running `litestream replicate` process
+over the IPC control socket. The daemon must already be running.
+
+
+## Usage
+
+```
+litestream register [arguments] DB_PATH
+```
+
+
+## Arguments
+
+```
+-replica URL
+    Replica destination URL (e.g., s3://bucket/prefix, file:///backup/path).
+    Required.
+
+-socket PATH
+    Path to the control socket.
+    Defaults to /var/run/litestream.sock
+
+-timeout SECONDS
+    Maximum time to wait in seconds.
+    Defaults to 30.
+
+-json
+    Output raw JSON instead of human-readable text.
+```
+
+
+## Behavior
+
+The `register` command is **idempotent**. If the database is already registered
+with the daemon, the command returns `already_registered` status and exits
+successfully (exit code 0). This allows scripts to safely call `register`
+without checking whether the database is already being replicated.
+
+
+## Output
+
+By default, the command displays a human-readable confirmation:
+
+```
+status: registered
+db_path: /path/to/my.db
+replica: s3://mybucket/my.db
+socket: /var/run/litestream.sock
+```
+
+With `-json`, the response is a JSON object:
+
+| Field | Description |
+|-------|-------------|
+| `status` | Either `registered` or `already_registered` |
+| `db_path` | Absolute path to the database file |
+| `replica` | Replica URL that was registered |
+| `socket` | Control socket path used |
+
+
+## Examples
+
+### Register with S3 replica
+
+```
+$ litestream register -replica s3://mybucket/db /path/to/my.db
+status: registered
+db_path: /path/to/my.db
+replica: s3://mybucket/db
+socket: /var/run/litestream.sock
+```
+
+### Register with file replica
+
+```
+$ litestream register -replica file:///backup/my.db /path/to/my.db
+status: registered
+db_path: /path/to/my.db
+replica: file:///backup/my.db
+socket: /var/run/litestream.sock
+```
+
+### Idempotent registration
+
+Calling `register` on an already-registered database succeeds:
+
+```
+$ litestream register -replica s3://mybucket/db /path/to/my.db
+status: already registered
+db_path: /path/to/my.db
+replica: s3://mybucket/db
+socket: /var/run/litestream.sock
+```
+
+### JSON output
+
+```
+$ litestream register -json -replica s3://mybucket/db /path/to/my.db
+{
+  "status": "registered",
+  "db_path": "/path/to/my.db",
+  "replica": "s3://mybucket/db",
+  "socket": "/var/run/litestream.sock"
+}
+```
+
+### Custom socket path
+
+```
+$ litestream register -socket /tmp/litestream.sock -replica s3://mybucket/db /path/to/my.db
+```
+
+
+## See Also
+
+- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `POST /register`
+- [Command: unregister](/reference/unregister) — Remove a database from the daemon
+- [Command: replicate](/reference/replicate) — Start the replication daemon
+- [Configuration Reference](/reference/config) — Complete configuration options

--- a/content/reference/start.md
+++ b/content/reference/start.md
@@ -1,0 +1,125 @@
+---
+title : "Command: start"
+date: 2026-05-28T00:00:00Z
+layout: docs
+menu:
+  docs:
+    parent: "reference"
+weight: 548
+---
+
+{{< since version="0.5.12" >}} The `start` command resumes replication for a
+database that was previously stopped via the `stop` command. The database must
+already be registered with the daemon.
+
+The `start` command communicates with a running `litestream replicate` process
+over the IPC control socket. The daemon must already be running.
+
+{{< alert icon="💡" text="The `start` command is different from `litestream replicate`. Use `replicate` to launch the daemon process. Use `start` to resume replication for a specific database on an already-running daemon." >}}
+
+
+## Usage
+
+```
+litestream start [arguments] DB_PATH
+```
+
+
+## Arguments
+
+```
+-socket PATH
+    Path to the control socket.
+    Defaults to /var/run/litestream.sock
+
+-timeout SECONDS
+    Maximum time to wait in seconds.
+    Defaults to 30.
+
+-json
+    Output raw JSON instead of human-readable text.
+```
+
+
+## Behavior
+
+The `start` command is **idempotent**. If the database is already running
+(replicating), the command returns `already_running` status and exits
+successfully (exit code 0). This allows scripts to safely call `start`
+without checking the current replication state.
+
+
+## Output
+
+By default, the command displays a human-readable confirmation:
+
+```
+status: started
+db_path: /path/to/my.db
+state: running
+txid: 42
+socket: /var/run/litestream.sock
+```
+
+With `-json`, the response is a JSON object:
+
+| Field | Description |
+|-------|-------------|
+| `status` | Either `started` or `already_running` |
+| `db_path` | Absolute path to the database file |
+| `state` | Current state after command: `running` |
+| `txid` | Current transaction ID |
+| `socket` | Control socket path used |
+
+
+## Examples
+
+### Start replication
+
+```
+$ litestream start /path/to/my.db
+status: started
+db_path: /path/to/my.db
+state: running
+txid: 42
+socket: /var/run/litestream.sock
+```
+
+### Idempotent start
+
+Calling `start` on an already-running database succeeds:
+
+```
+$ litestream start /path/to/my.db
+status: already_running
+db_path: /path/to/my.db
+state: running
+txid: 42
+socket: /var/run/litestream.sock
+```
+
+### JSON output
+
+```
+$ litestream start -json /path/to/my.db
+{
+  "status": "started",
+  "db_path": "/path/to/my.db",
+  "state": "running",
+  "txid": 42,
+  "socket": "/var/run/litestream.sock"
+}
+```
+
+### Custom socket path
+
+```
+$ litestream start -socket /tmp/litestream.sock /path/to/my.db
+```
+
+
+## See Also
+
+- [Command: stop](/reference/stop) — Stop replication for a database
+- [Command: replicate](/reference/replicate) — Start the replication daemon
+- [Command: list](/reference/list) — List all managed databases

--- a/content/reference/stop.md
+++ b/content/reference/stop.md
@@ -1,0 +1,130 @@
+---
+title : "Command: stop"
+date: 2026-05-28T00:00:00Z
+layout: docs
+menu:
+  docs:
+    parent: "reference"
+weight: 549
+---
+
+{{< since version="0.5.12" >}} The `stop` command pauses replication for a
+database without removing it from the daemon. The database remains registered
+and can be resumed with the `start` command. Before stopping, it performs a
+final sync to ensure all data is replicated.
+
+The `stop` command communicates with a running `litestream replicate` process
+over the IPC control socket. The daemon must already be running.
+
+
+## Usage
+
+```
+litestream stop [arguments] DB_PATH
+```
+
+
+## Arguments
+
+```
+-socket PATH
+    Path to the control socket.
+    Defaults to /var/run/litestream.sock
+
+-timeout SECONDS
+    Maximum time to wait in seconds.
+    Defaults to 30.
+
+-json
+    Output raw JSON instead of human-readable text.
+```
+
+
+## Behavior
+
+The `stop` command is **idempotent**. If the database is already stopped, the
+command returns `already_stopped` status and exits successfully (exit code 0).
+This allows scripts to safely call `stop` without checking the current
+replication state.
+
+The `stop` command always waits for shutdown and final sync to complete before
+returning. The database remains registered with the daemon and can be resumed
+using the `start` command.
+
+
+## Output
+
+By default, the command displays a human-readable confirmation:
+
+```
+status: stopped
+db_path: /path/to/my.db
+state: stopped
+txid: 42
+socket: /var/run/litestream.sock
+```
+
+With `-json`, the response is a JSON object:
+
+| Field | Description |
+|-------|-------------|
+| `status` | Either `stopped` or `already_stopped` |
+| `db_path` | Absolute path to the database file |
+| `state` | Current state after command: `stopped` |
+| `txid` | Final transaction ID after sync |
+| `socket` | Control socket path used |
+
+
+## Examples
+
+### Stop replication
+
+```
+$ litestream stop /path/to/my.db
+status: stopped
+db_path: /path/to/my.db
+state: stopped
+txid: 42
+socket: /var/run/litestream.sock
+```
+
+### Idempotent stop
+
+Calling `stop` on an already-stopped database succeeds:
+
+```
+$ litestream stop /path/to/my.db
+status: already_stopped
+db_path: /path/to/my.db
+state: stopped
+txid: 42
+socket: /var/run/litestream.sock
+```
+
+### JSON output
+
+```
+$ litestream stop -json /path/to/my.db
+{
+  "status": "stopped",
+  "db_path": "/path/to/my.db",
+  "state": "stopped",
+  "txid": 42,
+  "socket": "/var/run/litestream.sock"
+}
+```
+
+### Custom timeout
+
+Wait up to 60 seconds for the final sync:
+
+```
+$ litestream stop -timeout 60 /path/to/my.db
+```
+
+
+## See Also
+
+- [Command: start](/reference/start) — Resume replication for a database
+- [Command: unregister](/reference/unregister) — Remove a database from the daemon entirely
+- [Command: replicate](/reference/replicate) — Start the replication daemon

--- a/content/reference/unregister.md
+++ b/content/reference/unregister.md
@@ -1,0 +1,141 @@
+---
+title : "Command: unregister"
+date: 2026-05-28T00:00:00Z
+layout: docs
+menu:
+  docs:
+    parent: "reference"
+weight: 547
+---
+
+{{< since version="0.5.12" >}} The `unregister` command dynamically removes a
+database from a running Litestream daemon without requiring a restart. Before
+completing, it performs a final sync to ensure all data is replicated.
+
+The `unregister` command communicates with a running `litestream replicate` process
+over the IPC control socket. The daemon must already be running.
+
+
+## Usage
+
+```
+litestream unregister [arguments] DB_PATH
+```
+
+
+## Arguments
+
+```
+-socket PATH
+    Path to the control socket.
+    Defaults to /var/run/litestream.sock
+
+-timeout SECONDS
+    Maximum time to wait in seconds.
+    Defaults to 30.
+
+-dry-run
+    Preview what would be unregistered without changing the daemon.
+
+-json
+    Output raw JSON instead of human-readable text.
+```
+
+
+## Behavior
+
+The `unregister` command is **idempotent**. If the database is not currently
+registered with the daemon, the command returns `already_unregistered` status
+and exits successfully (exit code 0). This allows scripts to safely call
+`unregister` without checking whether the database is currently being replicated.
+
+When unregistering a database, Litestream performs a final sync to ensure all
+pending changes are replicated before removing the database from management.
+
+
+## Output
+
+By default, the command displays a human-readable confirmation:
+
+```
+status: unregistered
+db_path: /path/to/my.db
+final_txid: 42
+socket: /var/run/litestream.sock
+```
+
+With `-json`, the response is a JSON object:
+
+| Field | Description |
+|-------|-------------|
+| `status` | Either `unregistered` or `already_unregistered` |
+| `db_path` | Absolute path to the database file |
+| `final_txid` | Last transaction ID synced before unregistering |
+| `socket` | Control socket path used |
+
+
+## Examples
+
+### Unregister a database
+
+```
+$ litestream unregister /path/to/my.db
+status: unregistered
+db_path: /path/to/my.db
+final_txid: 42
+socket: /var/run/litestream.sock
+```
+
+### Dry run
+
+Preview what would be unregistered without making changes:
+
+```
+$ litestream unregister -dry-run /path/to/my.db
+Dry run: unregister request preview
+  database: /path/to/my.db
+  socket: /var/run/litestream.sock
+  replicas: daemon-managed replica for this database
+  final sync: daemon close will sync the database and replica before the command completes
+  timeout: 30s
+No unregister request was sent.
+```
+
+### Idempotent unregistration
+
+Calling `unregister` on an already-unregistered database succeeds:
+
+```
+$ litestream unregister /path/to/my.db
+status: already_unregistered
+db_path: /path/to/my.db
+final_txid: 0
+socket: /var/run/litestream.sock
+```
+
+### JSON output
+
+```
+$ litestream unregister -json /path/to/my.db
+{
+  "status": "unregistered",
+  "db_path": "/path/to/my.db",
+  "final_txid": 42,
+  "socket": "/var/run/litestream.sock"
+}
+```
+
+### Custom timeout
+
+Wait up to 60 seconds for the final sync to complete:
+
+```
+$ litestream unregister -timeout 60 /path/to/my.db
+```
+
+
+## See Also
+
+- [IPC Endpoints](/reference/ipc) — Unix socket endpoints including `POST /unregister`
+- [Command: register](/reference/register) — Add a database to the daemon
+- [Command: replicate](/reference/replicate) — Start the replication daemon


### PR DESCRIPTION
## Summary

- Add reference pages for 6 daemon control-socket commands: `info`, `list`, `register`, `unregister`, `start`, `stop`
- Each page documents purpose, prerequisite (running daemon with socket enabled), arguments/flags, output format, idempotency behavior, and examples
- Update `content/reference/_index.md` with a new "Daemon Control Commands" section
- Version-gate all commands with `{{< since version="0.5.12" >}}`

Closes #289

## Test plan

- [x] Markdown linting passes
- [ ] Links resolve correctly in local dev server
- [ ] Content matches existing style/voice