### PR TITLE
docs(how-it-works): rewrite for v0.5 LTX architecture

### DIFF
--- a/content/how-it-works/_index.md
+++ b/content/how-it-works/_index.md
@@ -45,10 +45,10 @@ and restarting the WAL file. Instead, it continually reads new WAL pages and
 manually calls out to SQLite to perform checkpoints as necessary.
 
 New WAL pages are packaged into _LTX files_ (Litestream Transaction files).
-Every write transaction is assigned a monotonically incrementing _transaction
-ID_ (TXID), and each LTX file contains the page data for a contiguous range of
-transactions along with checksums to ensure consistency. LTX files are named
-after the TXID range they cover—for example,
+Each sync assigns the next monotonically incrementing _transaction ID_ (TXID)
+to the batch of new WAL pages—which may span one or more SQLite write
+transactions—and writes them as an LTX file along with checksums to ensure
+consistency. LTX files are named after the TXID range they cover—for example,
 `0000000000000001-0000000000000005.ltx` covers TXIDs 1 through 5.
 
 LTX files are staged in a hidden directory next to your database (e.g.
@@ -83,11 +83,12 @@ intervals and snapshot frequency are configurable—see the
 
 ## Restoring a database
 
-To restore a database, Litestream fetches the most recent snapshot and then
-applies each subsequent LTX file in TXID order to bring the database up to the
-requested point in time. Because TXIDs form a contiguous sequence, Litestream
-can verify that no transactions are missing before restoring—any gap in the
-sequence would otherwise result in a corrupted database file.
+To restore a database, Litestream fetches the latest snapshot at or before the
+requested point in time and then applies each subsequent LTX file in TXID order
+to bring the database up to that point. Because TXIDs form a contiguous
+sequence, Litestream can verify that no transactions are missing before
+restoring—any gap in the sequence would otherwise result in a corrupted
+database file.
 
 Earlier v0.3.x releases tracked replication state using randomly-generated
 "generation" IDs and a directory of shadow WAL files. Litestream v0.5 replaces

--- a/content/how-it-works/_index.md
+++ b/content/how-it-works/_index.md
@@ -10,9 +10,12 @@ weight: 130
 
 Litestream is a streaming replication tool for SQLite databases. It runs as a
 separate background process and continuously copies write-ahead log pages from
-disk to one or more replicas. This asynchronous replication provides disaster
-recovery similar to what is available with database servers like Postgres or
-MySQL.
+disk to a replica. This asynchronous replication provides disaster recovery
+similar to what is available with database servers like Postgres or MySQL.
+
+Each database replicates to a single replica destination. If you need multiple
+backup destinations, see the [replica settings](/reference/config/#legacy-multiple-replicas)
+section of the configuration reference for alternatives.
 
 
 ## Understanding the WAL
@@ -34,68 +37,79 @@ _checkpointing_ and can only be done when no transactions are active. That is
 the crux of what lets Litestream replicate SQLite.
 
 
-## The shadow WAL
+## From WAL to LTX
 
 Litestream works by effectively taking over the checkpointing process. It starts
 a long-running read transaction to prevent any other process from checkpointing
-and restarting the WAL file. Instead, it continually copies over new WAL pages
-to a staging area called the _shadow WAL_ and manually calls out to SQLite to
-perform checkpoints as necessary.
+and restarting the WAL file. Instead, it continually reads new WAL pages and
+manually calls out to SQLite to perform checkpoints as necessary.
 
-The shadow WAL is a directory next to your SQLite database where WAL files are
-effectively recreated as a sequence. The first shadow WAL file starts with
-`00000000.wal` and when a checkpoint occurs then it starts copying to
-`00000001.wal`.
+New WAL pages are packaged into _LTX files_ (Litestream Transaction files).
+Every write transaction is assigned a monotonically incrementing _transaction
+ID_ (TXID), and each LTX file contains the page data for a contiguous range of
+transactions along with checksums to ensure consistency. LTX files are named
+after the TXID range they cover—for example,
+`0000000000000001-0000000000000005.ltx` covers TXIDs 1 through 5.
 
-These WAL files contain the original WAL frames & checksums to ensure
-consistency. To restore a database, we can simply start from a snapshot of the
-database at some point in time and replay each WAL afterward to get it to the
-current state.
+LTX files are staged in a hidden directory next to your database (e.g.
+`/var/lib/.db-litestream` for a database at `/var/lib/db`) and then uploaded to
+the replica, where they are organized by compaction level under an `ltx/`
+prefix.
 
 For more information about Litestream's checkpoint strategy and configuration
 options, see the [WAL Truncate Threshold Configuration
 guide](/guides/wal-truncate-threshold).
 
 
-## Snapshots & generations
+## Compaction & snapshots
 
-In order to accurately restore a database, a snapshot and all subsequent WAL
-frames must be available. Any break in the WAL frames would result in a
-corrupted restored database file. This collection of snapshots & contiguous
-WAL files is called a _generation_ in Litestream.
+Litestream writes LTX files continuously as transactions occur, so the lowest
+level—called _L0_—accumulates many small files. To keep restores fast, a
+background compaction process periodically merges files from one level into
+larger files at the next level:
 
-When Litestream first starts replicating a database, it creates a new
-generation. This is simply a 16-character random hex string. A snapshot is
-created by copying the current state of the database and then all WAL files
-created after are named as 8-character incrementing hex values starting with
-zero.
+- **L0** — raw transaction files written continuously during replication.
+- **L1, L2, L3** — compacted files, merged every 30 seconds, 5 minutes, and
+  1 hour by default.
+- **Snapshot level** — a full copy of the database, created every 24 hours by
+  default.
 
-If Litestream detects that there is a break in the WAL frames then it will
-automatically start a new generation with a new random hex string and a
-snapshot. This ensures we always have a contiguous set of files to replay even
-if Litestream is stopped and misses WAL frames being written.
+This tiered approach means recent changes are available at fine granularity
+while older history is consolidated into fewer, larger files. Compaction
+intervals and snapshot frequency are configurable—see the
+[Configuration Reference](/reference/config) for details, and the
+[`ltx` command](/reference/ltx) for inspecting files at each level.
 
-This approach also has the benefit that two servers that accidentally share
-the same replica destination will not overwrite each other's data. However,
-note that it is not recommended to replicate two databases to the same exact
-replica path.
+
+## Restoring a database
+
+To restore a database, Litestream fetches the most recent snapshot and then
+applies each subsequent LTX file in TXID order to bring the database up to the
+requested point in time. Because TXIDs form a contiguous sequence, Litestream
+can verify that no transactions are missing before restoring—any gap in the
+sequence would otherwise result in a corrupted database file.
+
+Earlier v0.3.x releases tracked replication state using randomly-generated
+"generation" IDs and a directory of shadow WAL files. Litestream v0.5 replaces
+both concepts with TXID-based LTX files. See the
+[Migration Guide](/docs/migration) if you are upgrading from v0.3.x.
 
 
 ## Retention
 
-The time to restore a database from backup is directly related to the number and
-size of WAL files since the snapshot. To avoid having the WAL files grow without
-bound, Litestream performs new snapshots of the data periodically and removes old
-WAL files.
+The time to restore a database from backup is directly related to the number
+and size of LTX files since the last snapshot. To avoid having these files grow
+without bound, Litestream performs new snapshots of the data periodically and
+removes old LTX files.
 
 This process is broken up into two steps. First, a snapshot interval is set to
 re-snapshot the database on a regular basis. This allows you to keep copies of
 your database at multiple points in time.
 
 The second step is retention enforcement. This periodically runs and removes any
-snapshots older than the retention time as well as remove any WAL files older
-than the oldest snapshot. By default, this the retention time is 24 hours.
-Litestream will always ensure there is at least one snapshot retained.
+snapshots older than the retention period as well as any LTX files older than
+the oldest snapshot. By default, the retention period is 24 hours. Litestream
+will always ensure there is at least one snapshot retained.
 
 This two-step process allows for more use cases such as snapshotting every day
 but retaining snapshots for a week.

--- a/content/how-it-works/_index.md
+++ b/content/how-it-works/_index.md
@@ -44,7 +44,7 @@ a long-running read transaction to prevent any other process from checkpointing
 and restarting the WAL file. Instead, it continually reads new WAL pages and
 manually calls out to SQLite to perform checkpoints as necessary.
 
-New WAL pages are packaged into _LTX files_ (Litestream Transaction files).
+New WAL pages are packaged into _LTX files_ (Litestream Transaction Log files).
 Each sync assigns the next monotonically incrementing _transaction ID_ (TXID)
 to the batch of new WAL pages—which may span one or more SQLite write
 transactions—and writes them as an LTX file along with checksums to ensure


### PR DESCRIPTION
## Summary
- Rewrite `content/how-it-works/_index.md` around the v0.5 architecture: WAL → LTX conversion, TXIDs, and TXID-range filenames (`0000000000000001-0000000000000005.ltx`) staged under the hidden `.<db>-litestream` directory
- Replace the v0.3 "shadow WAL" section with **From WAL to LTX** and the "Snapshots & generations" section with **Compaction & snapshots** (L0 → L1/L2/L3 → snapshot level, with verified default intervals: 30s / 5m / 1h / 24h) and **Restoring a database** (LTX replay in TXID order)
- Add a short v0.3 → v0.5 note (generations/shadow WAL replaced by TXID-based LTX files) linking the migration guide
- Fix "one or more replicas" — v0.5 supports a single replica per database; link the legacy multiple-replicas config section
- Fix the retention section typo ("this the retention time") and update it to reference LTX files

All architecture details verified against litestream source at main (c96c0f4): `MetaDirSuffix`/`LTXLevelDir` layout, `SnapshotLevel = 9`, `DefaultCompactionLevels` (30s/5m/1h), snapshot interval/retention defaults (24h), and the multiple-replica rejection in `cmd/litestream/main.go`.

Closes #303

## Test plan
- [x] Markdown linting passes (`npm run lint:markdown`)
- [x] Links resolve to existing pages/anchors (`/reference/config#legacy-multiple-replicas`, `/reference/ltx`, `/docs/migration`, `/guides/wal-truncate-threshold`)
- [x] Content matches existing style/voice