### PR TITLE
docs(reference): fix wal page — remove nonexistent flags, document ltx alias

### DIFF
--- a/content/reference/wal.md
+++ b/content/reference/wal.md
@@ -10,76 +10,15 @@ weight: 570
 
 {{< alert icon="⚠️" text="The wal command has been deprecated in v0.5.0 and replaced with the ltx command." >}}
 
-The `wal` command lists WAL files available for a database or replica. This
-command is not typically used in normal usage and is mainly used for debugging.
-
-**For Litestream v0.5.0+, use the [`ltx` command]({{< ref "ltx" >}}) instead.**
-
-
-## Usage
-
-### List by database
-
-This command lists all WAL files across all replicas for a database specified
-in the Litestream configuration file:
-
-```
-litestream wal [arguments] DB_PATH
-```
-
-
-### List by replica URL
-
-This command lists all WAL files for a single replica URL. This approach is
-useful when you do not have a configuration file.
-
-```
-litestream wal [arguments] REPLICA_URL
-```
-
-
-## Arguments
-
-```
--config PATH
-    Specifies the configuration file.
-    Defaults to /etc/litestream.yml
-
--no-expand-env
-    Disables environment variable expansion in configuration file.
-
--replica NAME
-    Optional, filters by replica.
-    Only applies when listing database snapshots.
-
--generation NAME
-    Optional, filter by a specific generation.
-```
-
-
-## Example
-
-### Database WAL files
-
-List all WAL files across all replicas for the `/var/lib/db` database:
+The `wal` command is a deprecated alias for the [`ltx` command]({{< ref "ltx" >}}).
+Running it prints a deprecation warning and then executes `ltx` with the same
+arguments:
 
 ```
 $ litestream wal /var/lib/db
+Warning: 'wal' command is deprecated, please use 'ltx' instead
 ```
 
-### Filter by replica name
-
-Lists all WAL files for the `/var/lib/db` database but filters by the `s3` replica:
-
-```
-$ litestream wal -replica s3 /var/lib/db
-```
-
-### Replica URL WAL files
-
-Lists all WAL files for a single replica URL:
-
-```
-$ litestream wal s3://mybkt.litestream.io/db
-```
-
+It accepts only the `ltx` flags (`-config`, `-no-expand-env`, `-level`,
+`-json`). See the [`ltx` command reference]({{< ref "ltx" >}}) for usage,
+arguments, and examples.


### PR DESCRIPTION
## Summary
- Remove documented `-replica` and `-generation` flags from `content/reference/wal.md` — they do not exist; `wal` is a deprecated alias for `ltx` (verified against `cmd/litestream/main.go` on litestream main, which prints a deprecation warning and runs `LTXCommand`)
- Remove the `litestream wal -replica s3 /var/lib/db` filter example, which fails with `flag provided but not defined: -replica`
- Reduce the page to a short deprecation pointer: shows the actual alias behavior (warning + ltx execution), lists the real accepted flags, and links to the `ltx` reference for full usage

Closes #308

## Test plan
- [x] Markdown linting passes (`npm run lint:markdown`)
- [x] Behavior verified against litestream main source (`wal` case delegates to `LTXCommand`)
- [ ] Links resolve correctly in local dev server
- [x] Content matches existing style/voice