### PR TITLE
docs(vfs): remove nonexistent env vars and SQL functions, document real PRAGMAs

### DIFF
--- a/content/guides/vfs-hydration/index.md
+++ b/content/guides/vfs-hydration/index.md
@@ -293,28 +293,20 @@ func main() {
 
 ## Monitoring hydration progress
 
-If implemented in your Litestream build, these SQL functions can monitor
-hydration status:
+Use these PRAGMAs to monitor hydration:
 
 ```sql
--- Get hydration progress as percentage (0-100)
-SELECT litestream_hydration_progress();
--- Returns: 75
+-- Get hydration progress as a percentage (0-100, one decimal place)
+PRAGMA litestream_hydration_progress;
+-- Returns: 75.0
 
--- Get hydration status
-SELECT litestream_hydration_status();
--- Returns: idle | restoring | catching_up | complete
+-- Get the local path of the hydrated database file
+PRAGMA litestream_hydration_file;
+-- Returns: /var/lib/litestream/hydrated.db
 ```
 
-| Status | Meaning |
-|--------|---------|
-| `idle` | Hydration not enabled or not started |
-| `restoring` | Initial database restoration in progress |
-| `catching_up` | Applying recent LTX files after initial restore |
-| `complete` | Hydration finished, all reads served locally |
-
-Check if your build includes these functions by attempting to call them. If not
-available, monitor the hydration file size as a rough progress indicator.
+`litestream_hydration_progress` returns `0` when hydration is not enabled and
+`100.0` once hydration is complete. Both PRAGMAs are read-only.
 
 
 ## Combining with write mode

--- a/content/guides/vfs/index.md
+++ b/content/guides/vfs/index.md
@@ -59,7 +59,8 @@ loading the extension if your client requires it.
 
 ## Configure the replica target
 
-Set `LITESTREAM_REPLICA_URL` to specify the replica location. The URL scheme
+Set `LITESTREAM_REPLICA_URL` to specify the replica location. This variable is
+**required**—the extension fails to initialize without it. The URL scheme
 determines the backend:
 
 ```sh
@@ -88,17 +89,9 @@ Standard cloud provider credentials are honored by their respective SDKs
 Additional configuration:
 
 - `LITESTREAM_LOG_LEVEL` — `DEBUG` or `INFO` (default).
-
-### Legacy S3 configuration
-
-The following S3-specific variables are still supported for backwards
-compatibility:
-
-- `LITESTREAM_S3_BUCKET`, `LITESTREAM_S3_PATH` — bucket and path to the replica.
-- `LITESTREAM_S3_REGION` — defaults to the bucket's region (or `us-east-1` with a custom endpoint).
-- `LITESTREAM_S3_ENDPOINT` — for S3-compatible stores (MinIO, R2, etc).
-- `LITESTREAM_S3_FORCE_PATH_STYLE` — `true` for path-style URLs (default: `false`).
-- `LITESTREAM_S3_SKIP_VERIFY` — `true` to skip TLS verification for testing (default: `false`).
+- `LITESTREAM_LOG_FILE` — append log output to a file instead of stdout.
+- `LITESTREAM_S3_ENDPOINT` — custom endpoint for S3-compatible stores (MinIO,
+  R2, etc.); alternative to the `endpoint` query parameter in the replica URL.
 
 
 ## Using the VFS as a loadable extension
@@ -286,7 +279,7 @@ SELECT litestream_set_time('5 minutes ago');  -- Set time travel point
 
 ## Limitations & constraints
 
-- Read-only: write attempts fail with `litestream is a read only vfs`.
+- Read-only: write attempts fail with `attempt to write a readonly database`.
 - CGO-only: requires `-tags vfs` and a CGO-enabled SQLite driver.
 - Network-bound latency: first access to a page incurs storage/network latency before it is cached.
 - High concurrency: designed for modest fan-out; very high reader counts will increase object-store requests.
@@ -360,7 +353,7 @@ a deeper explanation of the two-index isolation mechanism.
 
 - **"page not found" / non-contiguous errors**: ensure VFS retention is configured on the primary (`l0-retention` long enough) and the replica has no gaps.
 - **Slow queries**: reduce poll interval, enlarge cache, or run closer to the object store endpoint.
-- **TLS/endpoint issues with S3-compatible stores**: set `LITESTREAM_S3_ENDPOINT` and, if needed for testing only, `LITESTREAM_S3_SKIP_VERIFY=true`.
+- **TLS/endpoint issues with S3-compatible stores**: set the `endpoint` query parameter in the replica URL or the `LITESTREAM_S3_ENDPOINT` environment variable.
 - **No data visible**: VFS waits for an initial snapshot; confirm replication is running and the replica path is correct.
 
 

--- a/content/guides/vfs/index.md
+++ b/content/guides/vfs/index.md
@@ -353,7 +353,7 @@ a deeper explanation of the two-index isolation mechanism.
 
 - **"page not found" / non-contiguous errors**: ensure VFS retention is configured on the primary (`l0-retention` long enough) and the replica has no gaps.
 - **Slow queries**: reduce poll interval, enlarge cache, or run closer to the object store endpoint.
-- **TLS/endpoint issues with S3-compatible stores**: set the `endpoint` query parameter in the replica URL or the `LITESTREAM_S3_ENDPOINT` environment variable.
+- **TLS/endpoint issues with S3-compatible stores**: set the `endpoint` query parameter in the replica URL or the `LITESTREAM_S3_ENDPOINT` environment variable. For self-signed certificates, add `skip-verify=true` to the replica URL (testing only).
 - **No data visible**: VFS waits for an initial snapshot; confirm replication is running and the replica path is correct.
 
 

--- a/content/reference/vfs.md
+++ b/content/reference/vfs.md
@@ -80,7 +80,8 @@ sqlite> .open 'file:replica.db?vfs=litestream'
 
 ### Replica URL
 
-Set `LITESTREAM_REPLICA_URL` to specify the replica location using a URL format:
+Set `LITESTREAM_REPLICA_URL` to specify the replica location using a URL format.
+This variable is **required**—the loadable extension fails to initialize without it.
 
 | Scheme | Backend | Example |
 |--------|---------|---------|
@@ -107,21 +108,13 @@ LITESTREAM_REPLICA_URL="s3://mybucket/db?endpoint=<account>.r2.cloudflarestorage
 ### Other configuration
 
 - `LITESTREAM_LOG_LEVEL` — `DEBUG` or `INFO` (default).
+- `LITESTREAM_LOG_FILE` — append log output to a file instead of stdout.
+  {{< since version="0.5.7" >}}
+- `LITESTREAM_S3_ENDPOINT` — custom endpoint for S3-compatible storage
+  (alternative to the `endpoint` query parameter in the replica URL).
 - Standard cloud provider credentials (AWS, GCP, Azure) are honored by their
   respective SDKs. For example: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
   `AWS_PROFILE`, `GOOGLE_APPLICATION_CREDENTIALS`, `AZURE_STORAGE_ACCOUNT`.
-
-### Legacy S3 configuration
-
-The following S3-specific variables are still supported for backwards
-compatibility but `LITESTREAM_REPLICA_URL` is preferred:
-
-- `LITESTREAM_S3_BUCKET` — bucket containing the replica.
-- `LITESTREAM_S3_PATH` — prefix/path to the database replica.
-- `LITESTREAM_S3_REGION` — defaults to the bucket's region, or `us-east-1` when using a custom endpoint.
-- `LITESTREAM_S3_ENDPOINT` — custom endpoint for S3-compatible storage.
-- `LITESTREAM_S3_FORCE_PATH_STYLE` — `true` to force path-style URLs (default `false`).
-- `LITESTREAM_S3_SKIP_VERIFY` — `true` to skip TLS verification (default `false`; testing only).
 
 ### Runtime tuning
 
@@ -246,35 +239,44 @@ SELECT litestream_txid(), litestream_lag(), litestream_time();
 SELECT litestream_set_time('10 minutes ago');
 ```
 
-### Hydration monitoring functions
+### PRAGMA litestream_hydration_progress
 
-These functions are available when hydration is enabled:
-
-| Function | Description |
-|----------|-------------|
-| `litestream_hydration_progress()` | Returns hydration progress as percentage (0-100) |
-| `litestream_hydration_status()` | Returns status: `idle`, `restoring`, `catching_up`, `complete` |
-
-Example:
+{{< since version="0.5.7" >}} Returns [hydration](/guides/vfs-hydration) progress
+as a percentage (0–100, one decimal place). Returns `0` when hydration is not
+enabled. Read-only.
 
 ```sql
-SELECT litestream_hydration_status(), litestream_hydration_progress();
--- Returns: restoring, 45
+PRAGMA litestream_hydration_progress;
+-- Returns: 45.0
 ```
 
-### Write mode functions
+### PRAGMA litestream_hydration_file
 
-These functions are available when write mode is enabled:
-
-| Function | Description |
-|----------|-------------|
-| `litestream_write_buffer_size()` | Returns current write buffer size in bytes |
-
-Example:
+{{< since version="0.5.7" >}} Returns the local file path of the hydrated
+database. Read-only.
 
 ```sql
-SELECT litestream_write_buffer_size();
--- Returns: 8192
+PRAGMA litestream_hydration_file;
+-- Returns: /var/lib/litestream/hydrated.db
+```
+
+### PRAGMA litestream_write_enabled
+
+{{< since version="0.5.9" >}} Gets or sets [write mode](/guides/vfs-write-mode)
+at runtime.
+
+**Get current state:**
+
+```sql
+PRAGMA litestream_write_enabled;
+-- Returns: 0 (disabled) or 1 (enabled)
+```
+
+**Enable or disable:**
+
+```sql
+PRAGMA litestream_write_enabled = 1;   -- also accepts true, on
+PRAGMA litestream_write_enabled = 0;   -- also accepts false, off
 ```
 
 
@@ -292,7 +294,7 @@ SELECT litestream_write_buffer_size();
 
 ## Limitations & constraints
 
-- **Default read-only**: Write attempts return `litestream is a read only vfs` unless
+- **Default read-only**: Write attempts fail with `attempt to write a readonly database` unless
   [write mode](/guides/vfs-write-mode) is enabled with `LITESTREAM_WRITE_ENABLED=true`.
 - **Write mode constraints**: When enabled, write mode assumes a single writer. Multiple
   concurrent writers trigger conflict detection (not prevention). Applications must handle


### PR DESCRIPTION
## Summary
- Remove the "Legacy S3 configuration" sections from `content/reference/vfs.md` and `content/guides/vfs/index.md` — `LITESTREAM_S3_BUCKET`, `LITESTREAM_S3_PATH`, `LITESTREAM_S3_REGION`, `LITESTREAM_S3_FORCE_PATH_STYLE`, and `LITESTREAM_S3_SKIP_VERIFY` exist only in test helpers; kept `LITESTREAM_S3_ENDPOINT`, which production code reads
- Remove nonexistent SQL functions `litestream_hydration_progress()`, `litestream_hydration_status()`, and `litestream_write_buffer_size()` — the extension registers only `litestream_set_time`, `litestream_time`, `litestream_txid`, and `litestream_lag`
- Document the real interfaces (verified against litestream source):
  - `PRAGMA litestream_hydration_progress` — percentage, one decimal (v0.5.7)
  - `PRAGMA litestream_hydration_file` — hydrated database path (v0.5.7)
  - `PRAGMA litestream_write_enabled` — get/set write mode at runtime (v0.5.9)
  - `LITESTREAM_LOG_FILE` env var (v0.5.7)
- State that `LITESTREAM_REPLICA_URL` is **required** (extension errors without it), not merely "preferred"
- Fix read-only write error text: `litestream is a read only vfs` → `attempt to write a readonly database` (the actual SQLite error)

Closes #306

## Test plan
- [x] Markdown linting passes
- [x] PRAGMAs, env vars, and version tags verified against litestream source (`vfs.go`, `cmd/litestream-vfs/main.go`, `src/litestream-vfs.c`; release tags via `git tag --contains`)
- [x] No remaining references to removed env vars/functions in `content/`
- [ ] Links resolve correctly in local dev server