### PR TITLE
docs(site): bump documented version to 0.5.14

### DIFF
--- a/content/docs/migration.md
+++ b/content/docs/migration.md
@@ -48,10 +48,10 @@ Download and install the new version:
 
 ```bash
 # Download latest stable release (check https://github.com/benbjohnson/litestream/releases)
-wget https://github.com/benbjohnson/litestream/releases/download/v0.5.6/litestream-0.5.6-linux-x86_64.tar.gz
+wget https://github.com/benbjohnson/litestream/releases/download/v{{< version >}}/litestream-{{< version >}}-linux-x86_64.tar.gz
 
 # Extract and install
-tar -xzf litestream-0.5.6-linux-x86_64.tar.gz
+tar -xzf litestream-{{< version >}}-linux-x86_64.tar.gz
 sudo mv litestream /usr/local/bin/
 sudo chmod +x /usr/local/bin/litestream
 
@@ -181,8 +181,8 @@ If you need Age encryption, remain on v0.3.x until the feature is restored:
 litestream version
 
 # If you've already upgraded to v0.5, downgrade to latest v0.3
-wget https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.tar.gz
-tar -xzf litestream-v0.3.13-linux-amd64.tar.gz
+wget https://github.com/benbjohnson/litestream/releases/download/v0.3.14/litestream-v0.3.14-linux-amd64.tar.gz
+tar -xzf litestream-v0.3.14-linux-amd64.tar.gz
 sudo mv litestream /usr/local/bin/
 sudo systemctl restart litestream
 ```

--- a/content/guides/docker/index.md
+++ b/content/guides/docker/index.md
@@ -38,8 +38,8 @@ manager, and no OS distribution files.
 
 | Variant | Tags | Base |
 |---------|------|------|
-| Default (Debian) | `latest`, `0.5.9` | `debian:bookworm-slim` |
-| Hardened (Scratch) | `latest-scratch`, `0.5.9-scratch` | `scratch` |
+| Default (Debian) | `latest`, `0.5.14` | `debian:bookworm-slim` |
+| Hardened (Scratch) | `latest-scratch`, `0.5.14-scratch` | `scratch` |
 
 Existing users are unaffected — the default tags (`latest`, version numbers)
 continue to produce the Debian image.
@@ -59,7 +59,7 @@ docker pull litestream/litestream:latest-scratch
 ```
 
 Replace `litestream/litestream` with `litestream/litestream:latest-scratch` (or
-a version-pinned tag like `0.5.9-scratch`) in your Dockerfiles and run commands.
+a version-pinned tag like `0.5.14-scratch`) in your Dockerfiles and run commands.
 
 
 ## Running as a sidecar

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,8 +1,8 @@
 params:
-  litestreamVersion: 0.5.8
+  litestreamVersion: 0.5.14
   docsVersion: "0.5"
   versionBanner:
     version: "v0.5.x"
     status: "Latest - Actively maintained with new features and bug fixes"
     otherVersionUrl: "/v0.3/"
-    otherVersionText: "View v0.3.13 (Previous)"
+    otherVersionText: "View v0.3.14 (Previous)"


### PR DESCRIPTION
## Summary
- Bump `litestreamVersion` param `0.5.8` → `0.5.14` (`hugo.yaml`) so install pages render current download URLs
- Update version banner text `View v0.3.13 (Previous)` → `View v0.3.14 (Previous)`
- Replace hardcoded `v0.5.6` tarball URLs in `content/docs/migration.md` with the `{{< version >}}` shortcode
- Update the v0.3 downgrade tarball in the migration guide `v0.3.13` → `v0.3.14`
- Update Docker guide example tags `0.5.9`/`0.5.9-scratch` → `0.5.14`/`0.5.14-scratch`

Closes #302

## Verification
- [x] Site built with repo-pinned Hugo (`npm run build`, hugo-bin v0.121.1) — all pages render
- [x] Every rendered release download URL returns HTTP 200 (v0.5.14 .deb/.rpm/.tar.gz, v0.3.14 tarball)
- [x] Docker Hub tags `0.5.14` and `0.5.14-scratch` confirmed present
- [x] `npm run lint:markdown` passes
- [x] Rendered banner shows `View v0.3.14 (Previous)`; Windows guide renders `litestream v0.5.14`