### PR TITLE
docs(config): fix S3 SSE options and document storage-class

### DIFF
--- a/content/guides/s3-advanced/index.md
+++ b/content/guides/s3-advanced/index.md
@@ -8,9 +8,9 @@ menu:
 weight: 405
 ---
 
-This guide covers advanced S3 configuration options for tuning multipart upload
-performance. These settings control how Litestream uploads data to S3 and
-S3-compatible storage services.
+This guide covers advanced S3 configuration options, including multipart upload
+tuning and storage classes. These settings control how Litestream uploads data
+to S3 and S3-compatible storage services.
 
 {{< since version="0.5.0" >}} Part size and concurrency configuration options
 were added in Litestream v0.5.0.
@@ -232,6 +232,63 @@ Part size affects the number of API requests made to your storage provider:
 
 For high-volume databases with frequent syncs, consider larger part sizes to
 reduce the total number of API calls.
+
+## Storage Classes
+
+{{< since version="0.5.14" >}} The `storage-class` field sets the S3 storage
+class for objects that Litestream uploads. When it is not set, objects use
+the provider's default storage class (`STANDARD` on AWS S3).
+
+```yaml
+dbs:
+  - path: /path/to/db
+    replica:
+      type: s3
+      bucket: mybucket
+      path: db
+      storage-class: STANDARD_IA
+```
+
+The storage class can also be set as a URL query parameter:
+
+```yaml
+dbs:
+  - path: /path/to/db
+    replica:
+      url: s3://mybucket/db?storage-class=STANDARD_IA
+```
+
+The value is passed to S3 as-is, so any storage class supported by your
+provider works. Common AWS S3 choices:
+
+| Storage Class | Best For |
+|---------------|----------|
+| `STANDARD` | Default; frequent access, no retrieval fees |
+| `STANDARD_IA` | Long-retention replicas that are rarely restored |
+| `ONEZONE_IA` | Same as `STANDARD_IA` but single-AZ, lower cost |
+| `GLACIER_IR` | Archival storage with instant retrieval |
+| `INTELLIGENT_TIERING` | Automatic tiering based on access patterns |
+
+### Retention Caveats
+
+Infrequent-access and archival classes charge for a minimum storage duration
+(30 days for `STANDARD_IA` and `ONEZONE_IA`, 90 days for `GLACIER_IR`) and
+per-GB retrieval fees. Litestream continuously uploads new LTX files and
+deletes old ones during retention enforcement, so:
+
+- Objects deleted before the minimum storage duration still incur the full
+  minimum-duration charge. Use these classes only when your
+  [retention period](/reference/config#retention) is longer than the class's
+  minimum storage duration.
+- Restores read every LTX file needed to rebuild the database, so retrieval
+  fees apply to the full restore size.
+
+Avoid asynchronous archive classes such as `GLACIER` (Flexible Retrieval) and
+`DEEP_ARCHIVE`. Objects in these classes must be restored to S3 before they
+can be read, so `litestream restore` fails against them.
+
+S3-compatible providers support different storage class values — check your
+provider's documentation before setting this option.
 
 ## Troubleshooting
 

--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -679,9 +679,26 @@ The following settings are specific to S3 replicas:
   requests. Some S3-compatible providers don't support this header on certain
   operations. Automatically disabled for Tigris endpoints. Defaults to `true`.
 
-- `sse-customer-algorithm`—{{< since version="0.5.8" >}} SSE-C encryption algorithm.
+- `storage-class`—{{< since version="0.5.14" >}} Storage class applied to
+  objects uploaded to S3 (e.g. `STANDARD_IA`, `GLACIER_IR`). If not set, the
+  provider's default storage class is used. See the
+  [S3 Advanced Configuration Guide]({{< ref "s3-advanced#storage-classes" >}})
+  for cost trade-offs and retrieval caveats.
 
-- `sse-customer-key-md5`—{{< since version="0.5.8" >}} Base64-encoded MD5 digest of the SSE-C encryption key.
+- `sse-customer-algorithm`—{{< since version="0.5.6" >}} SSE-C encryption
+  algorithm. Only `AES256` is supported. Defaults to `AES256` when an SSE-C
+  key is provided, so it can usually be omitted.
+
+- `sse-customer-key`—{{< since version="0.5.6" >}} Base64-encoded 256-bit
+  encryption key for SSE-C. The key's MD5 digest is computed automatically.
+  Mutually exclusive with `sse-kms-key-id`.
+
+- `sse-customer-key-path`—{{< since version="0.5.6" >}} Path to a file
+  containing the base64-encoded SSE-C encryption key. Takes precedence over
+  `sse-customer-key`. Supports `~` expansion.
+
+- `sse-kms-key-id`—{{< since version="0.5.6" >}} AWS KMS key ID or ARN for
+  SSE-KMS encryption. Mutually exclusive with the SSE-C settings.
 
 These options can also be set via URL query parameters. {{< since version="0.5.8" >}}
 Both camelCase and hyphenated forms are accepted:
@@ -701,8 +718,11 @@ s3://bucket/path?signPayload=true&requireContentMD5=false
 | `part-size` | `partSize` | `5MB` | Size of each upload part |
 | `sign-payload` | `signPayload` | `true` | Sign request payload |
 | `require-content-md5` | `requireContentMD5` | `true` | Add Content-MD5 header |
+| `storage-class` | `storageClass` | — | S3 storage class |
 | `sse-customer-algorithm` | `sseCustomerAlgorithm` | — | SSE-C algorithm |
-| `sse-customer-key-md5` | `sseCustomerKeyMD5` | — | SSE-C key MD5 |
+| `sse-customer-key` | `sseCustomerKey` | — | SSE-C key (base64) |
+| `sse-customer-key-md5` | `sseCustomerKeyMD5` | — | SSE-C key MD5 digest |
+| `sse-kms-key-id` | `sseKmsKeyId` | — | SSE-KMS key ID |
 
 #### S3-Compatible Provider Requirements
 

--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -724,6 +724,8 @@ s3://bucket/path?signPayload=true&requireContentMD5=false
 | `sse-customer-key-md5` | `sseCustomerKeyMD5` | — | SSE-C key MD5 digest |
 | `sse-kms-key-id` | `sseKmsKeyId` | — | SSE-KMS key ID |
 
+{{< alert icon="⚠️" text="The SSE, `part-size`, and `concurrency` query parameters are only honored on replica URLs passed directly to commands such as `litestream restore s3://...`. They are **silently ignored** in a configuration file's `url:` field — use the equivalent YAML settings described above instead. Configuration file URLs apply only the `endpoint`, `region`, `forcePathStyle`, `skipVerify`, `sign-payload`, `require-content-md5`, and `storage-class` parameters." >}}
+
 #### S3-Compatible Provider Requirements
 
 Different S3-compatible storage providers have varying requirements for payload


### PR DESCRIPTION
## Summary
- Replace the nonexistent `sse-customer-key-md5` YAML key with the real `sse-customer-key` / `sse-customer-key-path` keys and add the missing `sse-kms-key-id` setting (all verified against `cmd/litestream/main.go` YAML tags on litestream main)
- Correct the SSE `since` tags from 0.5.8 to 0.5.6 — SSE (PR benbjohnson/litestream#902) first shipped in the v0.5.6 release per its release notes
- Add `storage-class` {{< since 0.5.14 >}} (PR benbjohnson/litestream#1321) to the S3 settings list
- Complete the URL query parameter table: `storage-class`/`storageClass`, `sse-customer-key`/`sseCustomerKey`, `sse-kms-key-id`/`sseKmsKeyId` (parse sites: `s3/replica_client.go:205-207`, `305-308`, `317-321`); `sse-customer-key-path` is intentionally absent since it is not parsed from URLs
- Add a Storage Classes section to the S3 Advanced guide with config + URL examples, an AWS class table, minimum-storage-duration/retrieval-fee caveats tied to retention, and a warning against asynchronous archive classes (`GLACIER`, `DEEP_ARCHIVE`) — this fixes the dangling "storage classes" link text in the S3 and S3-compatible guides

Closes #307

## Test plan
- [x] Markdown linting passes (`npm run lint:markdown`)
- [x] Site builds with pinned Hugo (`npm run build`)
- [x] Rendered output verified: `#storage-classes` anchor exists, config ref link resolves, `/reference/config#retention` anchor exists
- [x] Content matches existing style/voice (bullet + since-tag format, table formats)