### PR TITLE
docs(vfs-write-mode): use correct WriteSyncInterval and WriteBufferPath fields

### DIFF
--- a/content/guides/vfs-write-mode/index.md
+++ b/content/guides/vfs-write-mode/index.md
@@ -234,8 +234,8 @@ func main() {
 
     vfs := litestream.NewVFS(client, nil)
     vfs.WriteEnabled = true
-    vfs.SyncInterval = 1 * time.Second
-    vfs.BufferPath = "/tmp/litestream-buffer.db"
+    vfs.WriteSyncInterval = 1 * time.Second
+    vfs.WriteBufferPath = "/tmp/litestream-buffer.db"
 
     if err := sqlite3vfs.RegisterVFS("litestream", vfs); err != nil {
         log.Fatal(err)


### PR DESCRIPTION
The Go example in the write-mode guide sets `vfs.SyncInterval` and `vfs.BufferPath`, but the `VFS` struct exposes these as `WriteSyncInterval` and `WriteBufferPath` (see vfs.go), so the snippet as written fails to compile. Renamed the two lines to match the actual field names.

Closes #314