### PR TITLE
docs(go-library): fix GCS package path and stale Go version

### DIFF
--- a/content/guides/go-library/index.md
+++ b/content/guides/go-library/index.md
@@ -27,7 +27,7 @@ with your application lifecycle or want to customize replication behavior.
 
 ## Prerequisites
 
-- Go 1.24 or later.
+- Go 1.25 or later.
 - A SQLite driver. The examples use [`modernc.org/sqlite`](https://pkg.go.dev/modernc.org/sqlite) (pure Go, no CGO required).
 - Familiarity with Litestream concepts from the [Getting Started](/getting-started) guide.
 
@@ -281,7 +281,7 @@ The library supports all Litestream replica backends:
 |---------|---------------|------------|
 | Local filesystem | `github.com/benbjohnson/litestream/file` | `file://` |
 | Amazon S3 | `github.com/benbjohnson/litestream/s3` | `s3://` |
-| Google Cloud Storage | `github.com/benbjohnson/litestream/gcs` | `gs://` |
+| Google Cloud Storage | `github.com/benbjohnson/litestream/gs` | `gs://` |
 | Azure Blob Storage | `github.com/benbjohnson/litestream/abs` | `abs://` |
 | Alibaba Cloud OSS | `github.com/benbjohnson/litestream/oss` | `oss://` |
 | SFTP | `github.com/benbjohnson/litestream/sftp` | `sftp://` |

--- a/content/guides/vfs/index.md
+++ b/content/guides/vfs/index.md
@@ -27,7 +27,7 @@ LTX files.
 
 ## Prerequisites
 
-- Go 1.24+ with CGO enabled (compiler toolchain installed).
+- Go 1.25+ with CGO enabled (compiler toolchain installed).
 - A Litestream-managed replica already syncing to object storage.
 - SQLite clients that support loadable extensions (CLI, Python, etc.) or a Go application built with CGO.
 - Supported page sizes: 512–65536 bytes (auto-detected from LTX headers).

--- a/content/install/source.md
+++ b/content/install/source.md
@@ -33,7 +33,7 @@ binary.
 ### Prerequisites
 
 - CGO toolchain (gcc/clang)
-- Go 1.24+
+- Go 1.25+
 
 ### Build command
 

--- a/content/reference/vfs.md
+++ b/content/reference/vfs.md
@@ -18,7 +18,7 @@ Pre-built binaries are available in
 
 ## Build requirements
 
-- Go 1.24+ with a working CGO toolchain (gcc/clang).
+- Go 1.25+ with a working CGO toolchain (gcc/clang).
 - Build with the VFS & extension tags using the repository Makefile (handles platform flags):
 
 ```sh


### PR DESCRIPTION
## Summary
- Fix the Go library guide's backends table: GCS client package is `github.com/benbjohnson/litestream/gs` (the `gcs/` directory does not exist; the documented import fails to compile)
- Bump "Go 1.24" to "Go 1.25" in the go-library guide, VFS guide, and source install docs to match `go 1.25.0` in litestream's `go.mod` on main
- Also bump a fourth stale "Go 1.24+" mention found in `content/reference/vfs.md` (same class of fix, not listed in the issue)

Closes #313

## Test plan
- [x] Markdown linting passes (`npm run lint:markdown`)
- [x] Verified `gs/` exists (and `gcs/` does not) in the litestream repo
- [x] Verified `go 1.25.0` in litestream `go.mod` on main