### PR TITLE
docs: correct meta directory default to dot-prefixed .<filename>-litestream

### DIFF
--- a/content/guides/systemd/index.md
+++ b/content/guides/systemd/index.md
@@ -118,7 +118,7 @@ sudo systemctl stop litestream
 And then we'll delete our database:
 
 ```sh
-rm -rf friends.db friends.db-shm friends.db-wal friends.db-litestream
+rm -rf friends.db friends.db-shm friends.db-wal .friends.db-litestream
 ```
 
 This is the state our server would be in if it had crashed and we had rebuilt it

--- a/content/reference/config.md
+++ b/content/reference/config.md
@@ -380,7 +380,7 @@ Each database supports the following configuration options:
   Litestream automatically strips `sqlite://` and `sqlite3://` prefixes, allowing
   you to use the same `DATABASE_URL` with Litestream and other SQLite tools. See
   [SQLite Connection String Prefixes](#sqlite-connection-string-prefixes) below.
-- `meta-path`—Path to store Litestream metadata (defaults to `<path>-litestream`)
+- `meta-path`—Path to store Litestream metadata (defaults to a hidden `.<filename>-litestream` directory next to the database file, e.g. `/var/lib/db` → `/var/lib/.db-litestream`)
 - `monitor-interval`—How often to check for changes (default: `1s`)
 - `checkpoint-interval`—How often to perform WAL checkpoints using PASSIVE mode (default: `1m`, non-blocking)
 - `busy-timeout`—SQLite busy timeout (default: `1s`)

--- a/content/reference/reset.md
+++ b/content/reference/reset.md
@@ -49,10 +49,10 @@ them. This allows you to preview the reset operation before committing to it.
 ```
 $ litestream reset -dry-run /var/lib/db
 Dry run: local Litestream state would be reset for: /var/lib/db
-Would remove: /var/lib/db-litestream/ltx
+Would remove: /var/lib/.db-litestream/ltx
 Files that would be removed:
-  /var/lib/db-litestream/ltx/0000000000000001-0000000000000001.ltx
-  /var/lib/db-litestream/ltx/0000000000000002-0000000000000002.ltx
+  /var/lib/.db-litestream/ltx/0/0000000000000001-0000000000000001.ltx
+  /var/lib/.db-litestream/ltx/0/0000000000000002-0000000000000002.ltx
 No files were removed.
 ```
 
@@ -61,7 +61,7 @@ If no local LTX files exist, the dry run reports that:
 ```
 $ litestream reset -dry-run /var/lib/db
 Dry run: local Litestream state would be reset for: /var/lib/db
-Would remove: /var/lib/db-litestream/ltx
+Would remove: /var/lib/.db-litestream/ltx
 No local LTX files would be removed.
 ```
 

--- a/content/tips/index.md
+++ b/content/tips/index.md
@@ -76,8 +76,9 @@ apply those old WAL pages to your new database. Litestream also tracks changes
 via the WAL so it can cause replication issues if the WAL file is leftover.
 
 Additionally, Litestream currently does not track database deletions. If you
-remove your database and recreate it, you should delete the `-litestream`
-directory next to your database file and restart Litestream.
+remove your database and recreate it, you should delete the hidden
+`.<filename>-litestream` metadata directory next to your database file (e.g.
+`.db-litestream` for a database named `db`) and restart Litestream.
 
 
 


### PR DESCRIPTION
## Summary
- `content/reference/config.md` — `meta-path` default corrected from `<path>-litestream` to a hidden `.<filename>-litestream` directory next to the database file, with an example (`/var/lib/db` → `/var/lib/.db-litestream`)
- `content/reference/reset.md` — dry-run example paths now include the dot prefix (`/var/lib/.db-litestream/ltx`) and a level subdirectory (`ltx/0/...`) where LTX files actually live
- `content/tips/index.md` — "delete the `-litestream` directory" now names the hidden `.<filename>-litestream` metadata directory with an example
- `content/guides/systemd/index.md` — disaster-simulation `rm` command corrected to `.friends.db-litestream` (same bug, found while sweeping for other instances)

Verified against litestream source: `db.go` builds the path as `filepath.Join(dir, "."+file+MetaDirSuffix)` and stores LTX files under `LTXLevelDir(level)`.

Closes #320

## Test Plan
- [x] Markdown linting passes (`npm run lint:markdown`)
- [x] Paths verified against `db.go` on litestream main
- [x] Repo-wide sweep for remaining un-dotted `-litestream` references — none left (explicit `meta-path:` config example intentionally unchanged)